### PR TITLE
feat: realtime voice — tests + top-level exports (follow-up to PR #6)

### DIFF
--- a/src/praisonaiui/__init__.py
+++ b/src/praisonaiui/__init__.py
@@ -36,6 +36,8 @@ def __getattr__(name: str):
     _config_attrs = {"configure"}
     _features_attrs = {"BaseFeatureProtocol", "register_feature", "get_features",
                        "get_feature", "auto_register_defaults"}
+    _realtime_attrs = {"RealtimeProtocol", "OpenAIRealtimeManager", "set_realtime", 
+                       "get_realtime_manager", "set_realtime_manager"}
     _ui_attrs = {
         "layout", "card", "columns", "chart", "table", "text",
         # Tier 1
@@ -81,6 +83,12 @@ def __getattr__(name: str):
     if name in _features_attrs:
         from praisonaiui import features
         return getattr(features, name)
+    if name in _realtime_attrs:
+        from praisonaiui.features import realtime
+        # Handle alias for set_realtime
+        if name == "set_realtime":
+            return realtime.set_realtime_manager
+        return getattr(realtime, name)
     if name in _ui_attrs:
         from praisonaiui import ui
         return getattr(ui, name)
@@ -165,6 +173,12 @@ __all__ = [
     "get_features",
     "get_feature",
     "auto_register_defaults",
+    # Realtime voice protocol
+    "RealtimeProtocol",
+    "OpenAIRealtimeManager", 
+    "set_realtime",
+    "get_realtime_manager",
+    "set_realtime_manager",
     # UI component API
     "layout",
     "card",

--- a/tests/unit/test_realtime.py
+++ b/tests/unit/test_realtime.py
@@ -1,0 +1,225 @@
+"""Tests for realtime voice feature protocol conformance and session lifecycle."""
+
+import pytest
+from unittest import mock
+from unittest.mock import AsyncMock, patch
+
+from praisonaiui.features.realtime import (
+    RealtimeProtocol,
+    OpenAIRealtimeManager,
+    get_realtime_manager,
+    set_realtime_manager,
+)
+
+
+class TestRealtimeProtocolConformance:
+    """Test that OpenAIRealtimeManager correctly implements RealtimeProtocol."""
+    
+    def test_openai_manager_is_realtime_protocol(self):
+        """Verify protocol conformance."""
+        manager = OpenAIRealtimeManager()
+        assert isinstance(manager, RealtimeProtocol)
+    
+    def test_protocol_has_required_methods(self):
+        """Verify protocol defines all required abstract methods."""
+        # Get all abstract methods from RealtimeProtocol
+        abstract_methods = RealtimeProtocol.__abstractmethods__
+        expected_methods = {
+            'create_session', 'send_audio', 'receive_audio', 
+            'call_tool', 'close_session'
+        }
+        assert abstract_methods == expected_methods
+    
+    def test_openai_manager_implements_all_methods(self):
+        """Verify OpenAIRealtimeManager implements all protocol methods."""
+        manager = OpenAIRealtimeManager()
+        
+        # Check all abstract methods are implemented
+        for method_name in RealtimeProtocol.__abstractmethods__:
+            assert hasattr(manager, method_name)
+            assert callable(getattr(manager, method_name))
+        
+        # Check health method (non-abstract)
+        assert hasattr(manager, 'health')
+        assert callable(manager.health)
+
+
+class TestManagerSingleton:
+    """Test get/set realtime manager lifecycle."""
+    
+    def test_manager_round_trip(self):
+        """Test set_realtime_manager / get_realtime_manager round-trip."""
+        # Create custom manager
+        custom_manager = OpenAIRealtimeManager()
+        
+        # Set it
+        set_realtime_manager(custom_manager)
+        
+        # Get it back
+        retrieved = get_realtime_manager()
+        
+        # Should be the same instance
+        assert retrieved is custom_manager
+    
+    def test_default_manager_is_openai(self):
+        """Test default manager is OpenAIRealtimeManager instance."""
+        # Reset manager
+        set_realtime_manager(None)
+        
+        # Get default
+        default = get_realtime_manager()
+        
+        assert isinstance(default, OpenAIRealtimeManager)
+
+
+class TestSessionLifecycle:
+    """Test session creation, operations, and cleanup."""
+    
+    @pytest.mark.asyncio
+    async def test_session_lifecycle_without_openai(self):
+        """Test session lifecycle when OpenAI SDK not available."""
+        manager = OpenAIRealtimeManager()
+        
+        # Mock ImportError for openai package
+        with patch('praisonaiui.features.realtime.openai', None):
+            # Mock import to raise ImportError
+            with patch('builtins.__import__', side_effect=ImportError("No module named 'openai'")):
+                session_info = await manager.create_session()
+                
+                assert session_info["type"] == "error"
+                assert "openai package not installed" in session_info["error"]
+    
+    @pytest.mark.asyncio
+    async def test_session_lifecycle_with_mocked_openai(self):
+        """Test full session lifecycle with mocked OpenAI."""
+        manager = OpenAIRealtimeManager()
+        
+        # Mock OpenAI client and response
+        mock_response = mock.MagicMock()
+        mock_response.client_secret = "test_secret_123"
+        
+        mock_openai = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_client.realtime.sessions.create = AsyncMock(return_value=mock_response)
+        mock_openai.OpenAI.return_value = mock_client
+        
+        with patch('praisonaiui.features.realtime.openai', mock_openai):
+            # Create session
+            session_info = await manager.create_session(model="gpt-4o-realtime-preview")
+            
+            # Verify session created successfully
+            assert session_info["status"] == "created"
+            assert session_info["client_secret"] == "test_secret_123"
+            assert session_info["model"] == "gpt-4o-realtime-preview"
+            assert session_info["type"] == "webrtc"
+            assert "session_id" in session_info
+            
+            session_id = session_info["session_id"]
+            
+            # Test send_audio (should not raise)
+            await manager.send_audio(session_id, b"audio_data")
+            
+            # Test receive_audio
+            events = []
+            async for event in manager.receive_audio(session_id):
+                events.append(event)
+                break  # Just get first event
+            
+            assert len(events) == 1
+            assert events[0]["type"] == "conversation.item.created"
+            
+            # Test call_tool
+            tool_result = await manager.call_tool(session_id, "test_tool", {"call_id": "call_123"})
+            assert tool_result["type"] == "function_call_output"
+            assert tool_result["call_id"] == "call_123"
+            
+            # Test close session
+            await manager.close_session(session_id)
+            
+            # Verify session is removed from internal tracking
+            assert session_id not in manager._sessions
+    
+    @pytest.mark.asyncio
+    async def test_receive_audio_invalid_session(self):
+        """Test receive_audio with invalid session ID."""
+        manager = OpenAIRealtimeManager()
+        
+        events = []
+        async for event in manager.receive_audio("invalid_session_id"):
+            events.append(event)
+            break
+        
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+        assert "Session not found" in events[0]["error"]
+
+
+class TestHealthEndpoint:
+    """Test health endpoint behavior."""
+    
+    def test_health_without_openai(self):
+        """Test health when OpenAI not installed."""
+        manager = OpenAIRealtimeManager()
+        
+        with patch('builtins.__import__', side_effect=ImportError("No module named 'openai'")):
+            health = manager.health()
+            
+            assert health["status"] == "degraded"
+            assert health["provider"] == "OpenAIRealtimeManager"
+            assert health["reason"] == "openai not installed"
+    
+    def test_health_with_openai(self):
+        """Test health when OpenAI is available."""
+        manager = OpenAIRealtimeManager()
+        
+        # Add some sessions to test counter
+        manager._sessions["session_1"] = {"id": "session_1"}
+        manager._sessions["session_2"] = {"id": "session_2"}
+        
+        mock_openai = mock.MagicMock()
+        with patch('praisonaiui.features.realtime.openai', mock_openai):
+            health = manager.health()
+            
+            assert health["status"] == "ok"
+            assert health["provider"] == "OpenAIRealtimeManager"
+            assert health["active_sessions"] == 2
+
+
+class TestLazyImportInvariant:
+    """Test that importing praisonaiui doesn't eagerly load OpenAI SDK."""
+    
+    def test_import_praisonaiui_no_openai_import(self):
+        """Verify importing praisonaiui package doesn't import openai."""
+        # This test ensures lazy imports work correctly
+        import sys
+        
+        # Remove openai from modules if present
+        openai_modules = [mod for mod in sys.modules.keys() if mod.startswith('openai')]
+        for mod in openai_modules:
+            if mod in sys.modules:
+                del sys.modules[mod]
+        
+        # Import praisonaiui
+        import praisonaiui  # noqa: F401
+        
+        # Verify openai wasn't imported
+        openai_imported = any(mod.startswith('openai') for mod in sys.modules.keys())
+        assert not openai_imported, "OpenAI SDK was imported during praisonaiui import"
+    
+    def test_accessing_realtime_still_lazy(self):
+        """Test that accessing realtime attributes still uses lazy imports."""
+        import sys
+        
+        # Remove openai from modules if present
+        openai_modules = [mod for mod in sys.modules.keys() if mod.startswith('openai')]
+        for mod in openai_modules:
+            if mod in sys.modules:
+                del sys.modules[mod]
+        
+        # Access manager functions (should not import openai yet)
+        manager = get_realtime_manager()
+        assert isinstance(manager, OpenAIRealtimeManager)
+        
+        # OpenAI should still not be imported until we try to use it
+        openai_imported = any(mod.startswith('openai') for mod in sys.modules.keys())
+        assert not openai_imported, "OpenAI SDK was imported too early"

--- a/tests/unit/test_realtime.py
+++ b/tests/unit/test_realtime.py
@@ -78,20 +78,20 @@ class TestSessionLifecycle:
     @pytest.mark.asyncio
     async def test_session_lifecycle_without_openai(self):
         """Test session lifecycle when OpenAI SDK not available."""
+        import sys
         manager = OpenAIRealtimeManager()
         
-        # Mock ImportError for openai package
-        with patch('praisonaiui.features.realtime.openai', None):
-            # Mock import to raise ImportError
-            with patch('builtins.__import__', side_effect=ImportError("No module named 'openai'")):
-                session_info = await manager.create_session()
-                
-                assert session_info["type"] == "error"
-                assert "openai package not installed" in session_info["error"]
+        # Force `import openai` inside the function body to fail
+        with patch.dict(sys.modules, {"openai": None}):
+            session_info = await manager.create_session()
+            
+            assert session_info["type"] == "error"
+            assert "openai package not installed" in session_info["error"]
     
     @pytest.mark.asyncio
     async def test_session_lifecycle_with_mocked_openai(self):
         """Test full session lifecycle with mocked OpenAI."""
+        import sys
         manager = OpenAIRealtimeManager()
         
         # Mock OpenAI client and response
@@ -103,7 +103,7 @@ class TestSessionLifecycle:
         mock_client.realtime.sessions.create = AsyncMock(return_value=mock_response)
         mock_openai.OpenAI.return_value = mock_client
         
-        with patch('praisonaiui.features.realtime.openai', mock_openai):
+        with patch.dict(sys.modules, {"openai": mock_openai}):
             # Create session
             session_info = await manager.create_session(model="gpt-4o-realtime-preview")
             
@@ -170,6 +170,7 @@ class TestHealthEndpoint:
     
     def test_health_with_openai(self):
         """Test health when OpenAI is available."""
+        import sys
         manager = OpenAIRealtimeManager()
         
         # Add some sessions to test counter
@@ -177,7 +178,7 @@ class TestHealthEndpoint:
         manager._sessions["session_2"] = {"id": "session_2"}
         
         mock_openai = mock.MagicMock()
-        with patch('praisonaiui.features.realtime.openai', mock_openai):
+        with patch.dict(sys.modules, {"openai": mock_openai}):
             health = manager.health()
             
             assert health["status"] == "ok"


### PR DESCRIPTION
## Overview

Addresses gaps on issue #1 identified in the follow-up review of merged PR #6. Adds the missing `aiui.set_realtime(...)` / `OpenAIRealtimeManager` / `RealtimeProtocol` exports and a dedicated test module.

Work by `@claude` on branch `claude/issue-1-20260418-0609` (opened here because the Claude Assistant completed but did not open the PR).

Closes #1

## Files changed

| File | +/- | Why |
|------|----|-----|
| `src/praisonaiui/__init__.py` | +14/-0 | Expose `RealtimeProtocol`, `OpenAIRealtimeManager`, `set_realtime`, `get_realtime_manager`, `set_realtime_manager` via lazy `__getattr__` |
| `tests/unit/test_realtime.py` | +225/-0 | Protocol conformance + session lifecycle + health endpoint + lazy-import invariant tests |

## Local validation

```
$ timeout 90 env PYTHONPATH=src python -m pytest tests/unit/test_realtime.py -v --no-cov
tests/unit/test_realtime.py::TestRealtimeProtocolConformance::test_openai_manager_is_realtime_protocol PASSED
tests/unit/test_realtime.py::TestRealtimeProtocolConformance::test_protocol_has_required_methods PASSED
tests/unit/test_realtime.py::TestRealtimeProtocolConformance::test_openai_manager_implements_all_methods PASSED
tests/unit/test_realtime.py::TestManagerSingleton::test_manager_round_trip PASSED
tests/unit/test_realtime.py::TestManagerSingleton::test_default_manager_is_openai PASSED
tests/unit/test_realtime.py::TestSessionLifecycle::test_session_lifecycle_without_openai PASSED
tests/unit/test_realtime.py::TestSessionLifecycle::test_session_lifecycle_with_mocked_openai PASSED
tests/unit/test_realtime.py::TestSessionLifecycle::test_receive_audio_invalid_session PASSED
tests/unit/test_realtime.py::TestHealthEndpoint::test_health_without_openai PASSED
tests/unit/test_realtime.py::TestHealthEndpoint::test_health_with_openai PASSED
tests/unit/test_realtime.py::TestLazyImportInvariant::test_import_praisonaiui_no_openai_import PASSED
tests/unit/test_realtime.py::TestLazyImportInvariant::test_accessing_realtime_still_lazy PASSED
========================= 12 passed, 0 failed in 0.17s =========================
```

✅ **This PR is now ready for merge — all tests pass.**

## Scope boundary (what this PR does NOT do)

- Does not add PR body sections per §11b in the automated way — this body is a minimal bootstrap since `@claude` did not auto-open the PR. Update on force-push.
- Does not modify `src/praisonaiui/features/realtime.py` — only adds exports and tests.