### PR TITLE
fix: ruff --fix pass over audio/lifecycle/window_message test files

### DIFF
--- a/tests/unit/test_audio_hooks.py
+++ b/tests/unit/test_audio_hooks.py
@@ -1,64 +1,62 @@
 """Tests for audio hooks feature."""
 
-import asyncio
-import json
-import pytest
 import time
-from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from praisonaiui.features.audio import (
     AudioFeature,
-    on_audio_start,
-    on_audio_chunk,
-    on_audio_end,
-    register_audio_start_hook,
-    register_audio_chunk_hook,
-    register_audio_end_hook,
-    reset_audio_state,
-    _audio_start_hooks,
     _audio_chunk_hooks,
     _audio_end_hooks,
     _audio_sessions,
+    _audio_start_hooks,
     _audio_stats,
+    on_audio_chunk,
+    on_audio_end,
+    on_audio_start,
+    register_audio_chunk_hook,
+    register_audio_end_hook,
+    register_audio_start_hook,
+    reset_audio_state,
 )
 
 
 class TestAudioFeature:
     """Test AudioFeature protocol implementation."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     def test_feature_protocol(self):
         """Test that AudioFeature implements BaseFeatureProtocol correctly."""
         feature = AudioFeature()
-        
+
         assert feature.name == "audio"
         assert feature.description == "Streaming audio input hooks for STT"
         assert len(feature.routes()) == 4
         assert len(feature.cli_commands()) == 1
-    
+
     @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """Test health check reports correct state."""
         feature = AudioFeature()
-        
+
         # Add some hooks
         @on_audio_start
         async def start_hook(session_id):
             pass
-        
+
         @on_audio_chunk
         async def chunk_hook(session_id, pcm, sample_rate):
             pass
-        
+
         @on_audio_end
         async def end_hook(session_id):
             pass
-        
+
         health = await feature.health()
-        
+
         assert health["status"] == "ok"
         assert health["feature"] == "audio"
         assert health["start_hooks"] == 1
@@ -69,74 +67,74 @@ class TestAudioFeature:
 
 class TestAudioHookRegistration:
     """Test audio hook registration."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     def test_start_hook_registration(self):
         """Test audio start hook registration."""
-        
+
         @register_audio_start_hook
         def start_hook():
             pass
-        
+
         assert len(_audio_start_hooks) == 1
         assert _audio_start_hooks[0] == start_hook
-    
+
     def test_chunk_hook_registration(self):
         """Test audio chunk hook registration."""
-        
+
         @register_audio_chunk_hook
         def chunk_hook(pcm_data, sample_rate):
             pass
-        
+
         assert len(_audio_chunk_hooks) == 1
         assert _audio_chunk_hooks[0] == chunk_hook
-    
+
     def test_end_hook_registration(self):
         """Test audio end hook registration."""
-        
+
         @register_audio_end_hook
         def end_hook():
             pass
-        
+
         assert len(_audio_end_hooks) == 1
         assert _audio_end_hooks[0] == end_hook
-    
+
     def test_decorator_syntax(self):
         """Test decorator syntax for audio hooks."""
-        
+
         @on_audio_start
         def start(session_id):
             pass
-        
+
         @on_audio_chunk
         def chunk(session_id, pcm, sample_rate):
             pass
-        
+
         @on_audio_end
         def end(session_id):
             pass
-        
+
         assert len(_audio_start_hooks) == 1
         assert len(_audio_chunk_hooks) == 1
         assert len(_audio_end_hooks) == 1
         assert _audio_start_hooks[0] == start
         assert _audio_chunk_hooks[0] == chunk
         assert _audio_end_hooks[0] == end
-    
+
     def test_duplicate_registration_prevention(self):
         """Test that duplicate hook registration is prevented."""
-        
+
         def my_hook():
             pass
-        
+
         # Register the same hook multiple times
         register_audio_start_hook(my_hook)
         register_audio_start_hook(my_hook)
         register_audio_start_hook(my_hook)
-        
+
         # Should only appear once
         assert len(_audio_start_hooks) == 1
         assert _audio_start_hooks[0] == my_hook
@@ -144,124 +142,124 @@ class TestAudioHookRegistration:
 
 class TestAudioHookExecution:
     """Test audio hook execution."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     @pytest.mark.asyncio
     async def test_start_hooks_execution(self):
         """Test start hooks are executed."""
         execution_order = []
-        
+
         @on_audio_start
         def hook1(session_id):
             execution_order.append(1)
-        
+
         @on_audio_start
         async def hook2(session_id):
             execution_order.append(2)
-        
+
         @on_audio_start
         def hook3(session_id):
             execution_order.append(3)
-        
+
         # Create feature instance and trigger hooks
         feature = AudioFeature()
         await feature._trigger_start_hooks("test_session")
-        
+
         assert execution_order == [1, 2, 3]
-    
+
     @pytest.mark.asyncio
     async def test_chunk_hooks_execution(self):
         """Test chunk hooks are executed with correct parameters."""
         received_chunks = []
-        
+
         @on_audio_chunk
         def hook1(session_id, pcm_data, sample_rate):
             received_chunks.append(("hook1", len(pcm_data), sample_rate))
-        
+
         @on_audio_chunk
         async def hook2(session_id, pcm_data, sample_rate):
             received_chunks.append(("hook2", len(pcm_data), sample_rate))
-        
+
         # Create feature instance and trigger hooks
         feature = AudioFeature()
         test_data = b"test_pcm_data"
         test_rate = 16000
-        
+
         await feature._trigger_chunk_hooks("test_session", test_data, test_rate)
-        
+
         assert len(received_chunks) == 2
         assert ("hook1", len(test_data), test_rate) in received_chunks
         assert ("hook2", len(test_data), test_rate) in received_chunks
-    
+
     @pytest.mark.asyncio
     async def test_end_hooks_execution(self):
         """Test end hooks are executed."""
         execution_order = []
-        
+
         @on_audio_end
         def hook1(session_id):
             execution_order.append(1)
-        
+
         @on_audio_end
         async def hook2(session_id):
             execution_order.append(2)
-        
+
         @on_audio_end
         def hook3(session_id):
             execution_order.append(3)
-        
+
         # Create feature instance and trigger hooks
         feature = AudioFeature()
         await feature._trigger_end_hooks("test_session")
-        
+
         assert execution_order == [1, 2, 3]
-    
+
     @pytest.mark.asyncio
     async def test_hook_error_handling(self):
         """Test that hook errors don't break audio processing."""
         execution_order = []
-        
+
         @on_audio_start
         def good_hook1(session_id):
             execution_order.append(1)
-        
+
         @on_audio_start
         def failing_hook(session_id):
             execution_order.append("fail")
             raise RuntimeError("Hook failed")
-        
+
         @on_audio_start
         def good_hook2(session_id):
             execution_order.append(2)
-        
+
         # Should not raise exception
         feature = AudioFeature()
         await feature._trigger_start_hooks("test_session")
-        
+
         # All hooks should have been attempted
         assert execution_order == [1, "fail", 2]
 
 
 class TestAudioSessionManagement:
     """Test audio session management."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     @pytest.mark.asyncio
     async def test_session_creation_and_cleanup(self):
         """Test audio session lifecycle."""
         feature = AudioFeature()
         session_id = "test_session"
-        
+
         # Initially no sessions
         assert len(_audio_sessions) == 0
         assert _audio_stats["active_sessions"] == 0
-        
+
         # Simulate session creation
         _audio_sessions[session_id] = {
             "started_at": time.time(),
@@ -272,24 +270,24 @@ class TestAudioSessionManagement:
         }
         _audio_stats["total_sessions"] += 1
         _audio_stats["active_sessions"] += 1
-        
+
         assert len(_audio_sessions) == 1
         assert _audio_stats["active_sessions"] == 1
         assert session_id in _audio_sessions
-        
+
         # Simulate session cleanup
         del _audio_sessions[session_id]
         _audio_stats["active_sessions"] = max(0, _audio_stats["active_sessions"] - 1)
-        
+
         assert len(_audio_sessions) == 0
         assert _audio_stats["active_sessions"] == 0
-    
+
     @pytest.mark.asyncio
     async def test_chunk_processing_updates_session(self):
         """Test that chunk processing updates session stats."""
         feature = AudioFeature()
         session_id = "test_session"
-        
+
         # Create session
         _audio_sessions[session_id] = {
             "started_at": time.time(),
@@ -298,17 +296,17 @@ class TestAudioSessionManagement:
             "bytes_received": 0,
             "last_chunk_at": time.time(),
         }
-        
+
         # Process audio chunk
         test_data = b"test_audio_chunk_data"
         await feature._handle_audio_chunk(session_id, test_data, 16000)
-        
+
         # Check session was updated
         session = _audio_sessions[session_id]
         assert session["chunks_received"] == 1
         assert session["bytes_received"] == len(test_data)
         assert session["last_chunk_at"] > session["started_at"]
-        
+
         # Check global stats were updated
         assert _audio_stats["total_chunks"] == 1
         assert _audio_stats["total_bytes"] == len(test_data)
@@ -316,27 +314,27 @@ class TestAudioSessionManagement:
 
 class TestAudioStats:
     """Test audio statistics tracking."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     def test_initial_stats(self):
         """Test initial audio statistics."""
         assert _audio_stats["total_sessions"] == 0
         assert _audio_stats["active_sessions"] == 0
         assert _audio_stats["total_chunks"] == 0
         assert _audio_stats["total_bytes"] == 0
-    
+
     @pytest.mark.asyncio
     async def test_stats_tracking(self):
         """Test statistics are properly tracked."""
         feature = AudioFeature()
-        
+
         # Simulate multiple chunks from different sessions
         sessions = ["session1", "session2"]
         chunk_data = [b"chunk1", b"chunk2", b"chunk3"]
-        
+
         for session_id in sessions:
             _audio_sessions[session_id] = {
                 "started_at": time.time(),
@@ -347,37 +345,37 @@ class TestAudioStats:
             }
             _audio_stats["total_sessions"] += 1
             _audio_stats["active_sessions"] += 1
-        
+
         total_bytes = 0
         for session_id in sessions:
             for chunk in chunk_data:
                 await feature._handle_audio_chunk(session_id, chunk, 16000)
                 total_bytes += len(chunk)
-        
+
         # Check final stats
         assert _audio_stats["total_sessions"] == 2
         assert _audio_stats["active_sessions"] == 2
         assert _audio_stats["total_chunks"] == len(sessions) * len(chunk_data)
         assert _audio_stats["total_bytes"] == total_bytes
-    
+
     def test_reset_state(self):
         """Test state reset functionality."""
         # Modify state
         _audio_stats["total_sessions"] = 5
         _audio_stats["active_sessions"] = 2
         _audio_sessions["test"] = {}
-        
+
         @on_audio_start
         def hook(session_id):
             pass
-        
+
         assert len(_audio_start_hooks) == 1
         assert _audio_stats["total_sessions"] == 5
         assert len(_audio_sessions) == 1
-        
+
         # Reset state
         reset_audio_state()
-        
+
         # Should be back to initial state
         assert len(_audio_start_hooks) == 0
         assert _audio_stats["total_sessions"] == 0
@@ -386,55 +384,55 @@ class TestAudioStats:
 
 class TestAudioIntegration:
     """Integration tests for audio hooks."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_audio_state()
-    
+
     @pytest.mark.asyncio
     async def test_stt_pipeline_example(self):
         """Test the STT pipeline example from the issue."""
         # Simulate an STT buffer
         stt_buffer = {"chunks": [], "finalized": False, "transcript": ""}
-        
+
         @on_audio_start
         async def start(session_id):
             # Reset buffer for new session
             stt_buffer["chunks"].clear()
             stt_buffer["finalized"] = False
-        
+
         @on_audio_chunk
         async def chunk(session_id, pcm_data, sample_rate):
             # Accumulate audio chunks
             stt_buffer["chunks"].append(pcm_data)
-        
+
         @on_audio_end
         async def end(session_id):
             # Simulate STT processing
             if stt_buffer["chunks"]:
                 stt_buffer["transcript"] = f"Processed {len(stt_buffer['chunks'])} chunks"
                 stt_buffer["finalized"] = True
-        
+
         feature = AudioFeature()
-        
+
         # Simulate audio session
         await feature._trigger_start_hooks("test_session")
         assert len(stt_buffer["chunks"]) == 0
         assert not stt_buffer["finalized"]
-        
+
         # Send audio chunks
         chunks = [b"chunk1", b"chunk2", b"chunk3"]
         for chunk in chunks:
             await feature._trigger_chunk_hooks("test_session", chunk, 16000)
-        
+
         assert len(stt_buffer["chunks"]) == len(chunks)
         assert stt_buffer["chunks"] == chunks
-        
+
         # End session
         await feature._trigger_end_hooks("test_session")
         assert stt_buffer["finalized"]
         assert stt_buffer["transcript"] == "Processed 3 chunks"
-    
+
     @pytest.mark.asyncio
     async def test_multiple_stt_providers(self):
         """Test multiple STT providers receiving the same audio."""
@@ -443,85 +441,85 @@ class TestAudioIntegration:
             "deepgram": {"chunks": [], "active": False},
             "vosk": {"chunks": [], "active": False},
         }
-        
+
         @on_audio_start
         async def start_all(session_id):
             for provider in providers.values():
                 provider["active"] = True
                 provider["chunks"].clear()
-        
+
         @on_audio_chunk
         async def chunk_to_whisper(session_id, pcm_data, sample_rate):
             if providers["whisper"]["active"]:
                 providers["whisper"]["chunks"].append(pcm_data)
-        
+
         @on_audio_chunk
         async def chunk_to_deepgram(session_id, pcm_data, sample_rate):
             if providers["deepgram"]["active"]:
                 providers["deepgram"]["chunks"].append(pcm_data)
-        
+
         @on_audio_chunk
         async def chunk_to_vosk(session_id, pcm_data, sample_rate):
             if providers["vosk"]["active"]:
                 providers["vosk"]["chunks"].append(pcm_data)
-        
+
         @on_audio_end
         async def end_all(session_id):
             for provider in providers.values():
                 provider["active"] = False
-        
+
         feature = AudioFeature()
-        
+
         # Start session
         await feature._trigger_start_hooks("test_session")
-        
+
         # All providers should be active
         for provider in providers.values():
             assert provider["active"]
             assert len(provider["chunks"]) == 0
-        
+
         # Send audio chunk
         test_chunk = b"test_audio_data"
         await feature._trigger_chunk_hooks("test_session", test_chunk, 16000)
-        
+
         # All providers should have received the chunk
         for provider in providers.values():
             assert len(provider["chunks"]) == 1
             assert provider["chunks"][0] == test_chunk
-        
+
         # End session
         await feature._trigger_end_hooks("test_session")
-        
+
         # All providers should be deactivated
         for provider in providers.values():
             assert not provider["active"]
-    
+
     @pytest.mark.asyncio
     async def test_audio_session_ordering(self):
         """Test that audio chunks are processed in order."""
         received_chunks = []
-        
+
         @on_audio_chunk
         async def ordered_processor(session_id, pcm_data, sample_rate):
             # Decode chunk number from data
             chunk_num = int(pcm_data.decode())
             received_chunks.append(chunk_num)
-        
+
         feature = AudioFeature()
-        
+
         # Send chunks in order
         for i in range(10):
             chunk_data = str(i).encode()
             await feature._trigger_chunk_hooks("test_session", chunk_data, 16000)
-        
+
         # Chunks should be processed in order
         assert received_chunks == list(range(10))
-    
+
     @pytest.mark.asyncio
     async def test_concurrent_audio_sessions(self):
         """Test handling of concurrent audio sessions."""
         session_data = {}
-        
+
         @on_audio_chunk
         async def track_by_session(session_id, pcm_data, sample_rate):
             # Extract session ID from chunk data (simulated)
@@ -529,18 +527,18 @@ class TestAudioIntegration:
             if session_id not in session_data:
                 session_data[session_id] = []
             session_data[session_id].append(pcm_data)
-        
+
         feature = AudioFeature()
-        
+
         # Simulate chunks from multiple sessions
         sessions = ["session1", "session2", "session3"]
         chunks_per_session = 3
-        
+
         for session_id in sessions:
             for chunk_num in range(chunks_per_session):
                 chunk_data = f"{session_id}:chunk{chunk_num}".encode()
                 await feature._trigger_chunk_hooks("test_session", chunk_data, 16000)
-        
+
         # Each session should have received its chunks
         assert len(session_data) == len(sessions)
         for session_id in sessions:

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -2,63 +2,64 @@
 
 import asyncio
 import os
-import pytest
 import time
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
+
+import pytest
 
 from praisonaiui.features.lifecycle import (
     LifecycleFeature,
-    on_app_startup,
-    on_app_shutdown,
-    register_startup_hook,
-    register_shutdown_hook,
-    run_startup_hooks,
-    run_shutdown_hooks,
-    reset_lifecycle_state,
-    _startup_hooks,
-    _shutdown_hooks,
     _lifecycle_state,
+    _shutdown_hooks,
+    _startup_hooks,
+    on_app_shutdown,
+    on_app_startup,
+    register_shutdown_hook,
+    register_startup_hook,
+    reset_lifecycle_state,
+    run_shutdown_hooks,
+    run_startup_hooks,
 )
 
 
 class TestLifecycleFeature:
     """Test LifecycleFeature protocol implementation."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_lifecycle_state()
-    
+
     def test_feature_protocol(self):
         """Test that LifecycleFeature implements BaseFeatureProtocol correctly."""
         feature = LifecycleFeature()
-        
+
         assert feature.name == "lifecycle"
         assert feature.description == "Server startup and shutdown hook management"
         assert len(feature.routes()) == 2
         assert len(feature.cli_commands()) == 1
-    
+
     @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """Test health check reports correct state."""
         feature = LifecycleFeature()
-        
+
         # Add some hooks
         @on_app_startup
         async def startup1():
             pass
-        
+
         @on_app_shutdown
         async def shutdown1():
             pass
-        
+
         health = await feature.health()
-        
+
         assert health["status"] == "ok"
         assert health["feature"] == "lifecycle"
         assert health["startup_hooks"] == 1
         assert health["shutdown_hooks"] == 1
         assert health["startup_completed"] is False
-        
+
         # After startup
         await run_startup_hooks()
         health = await feature.health()
@@ -67,218 +68,218 @@ class TestLifecycleFeature:
 
 class TestLifecycleHooks:
     """Test lifecycle hook registration and execution."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_lifecycle_state()
-    
+
     def test_startup_hook_registration(self):
         """Test startup hook registration."""
         call_count = 0
-        
+
         @register_startup_hook
         def startup_hook():
             nonlocal call_count
             call_count += 1
-        
+
         assert len(_startup_hooks) == 1
         assert _startup_hooks[0] == startup_hook
-    
+
     def test_shutdown_hook_registration(self):
         """Test shutdown hook registration."""
         call_count = 0
-        
+
         @register_shutdown_hook
         def shutdown_hook():
             nonlocal call_count
             call_count += 1
-        
+
         assert len(_shutdown_hooks) == 1
         assert _shutdown_hooks[0] == shutdown_hook
-    
+
     def test_decorator_syntax(self):
         """Test decorator syntax for hooks."""
-        
+
         @on_app_startup
         def startup():
             pass
-        
+
         @on_app_shutdown
         def shutdown():
             pass
-        
+
         assert len(_startup_hooks) == 1
         assert len(_shutdown_hooks) == 1
         assert _startup_hooks[0] == startup
         assert _shutdown_hooks[0] == shutdown
-    
+
     def test_duplicate_registration_prevention(self):
         """Test that duplicate hook registration is prevented."""
-        
+
         def my_hook():
             pass
-        
+
         # Register the same hook multiple times
         register_startup_hook(my_hook)
         register_startup_hook(my_hook)
         register_startup_hook(my_hook)
-        
+
         # Should only appear once
         assert len(_startup_hooks) == 1
         assert _startup_hooks[0] == my_hook
-    
+
     @pytest.mark.asyncio
     async def test_startup_hooks_execution(self):
         """Test startup hooks are executed in order."""
         execution_order = []
-        
+
         @on_app_startup
         def hook1():
             execution_order.append(1)
-        
+
         @on_app_startup
         async def hook2():
             execution_order.append(2)
-        
+
         @on_app_startup
         def hook3():
             execution_order.append(3)
-        
+
         assert _lifecycle_state["startup_completed"] is False
-        
+
         await run_startup_hooks()
-        
+
         assert execution_order == [1, 2, 3]
         assert _lifecycle_state["startup_completed"] is True
         assert _lifecycle_state["startup_time"] > 0
-    
+
     @pytest.mark.asyncio
     async def test_shutdown_hooks_execution(self):
         """Test shutdown hooks are executed in order."""
         execution_order = []
-        
+
         @on_app_shutdown
         def hook1():
             execution_order.append(1)
-        
+
         @on_app_shutdown
         async def hook2():
             execution_order.append(2)
-        
+
         @on_app_shutdown
         def hook3():
             execution_order.append(3)
-        
+
         assert _lifecycle_state["shutdown_initiated"] is False
-        
+
         await run_shutdown_hooks()
-        
+
         assert execution_order == [1, 2, 3]
         assert _lifecycle_state["shutdown_initiated"] is True
         assert _lifecycle_state["shutdown_time"] > 0
-    
+
     @pytest.mark.asyncio
     async def test_startup_hook_failure_handling(self):
         """Test that startup hook failures don't break the process."""
         execution_order = []
-        
+
         @on_app_startup
         def good_hook1():
             execution_order.append(1)
-        
+
         @on_app_startup
         def failing_hook():
             execution_order.append("fail")
             raise RuntimeError("Hook failed")
-        
+
         @on_app_startup
         def good_hook2():
             execution_order.append(2)
-        
+
         # Should not raise exception
         await run_startup_hooks()
-        
+
         # All hooks should have been attempted
         assert execution_order == [1, "fail", 2]
         assert _lifecycle_state["startup_completed"] is True
-    
+
     @pytest.mark.asyncio
     async def test_shutdown_hook_failure_handling(self):
         """Test that shutdown hook failures don't break the process."""
         execution_order = []
-        
+
         @on_app_shutdown
         def good_hook1():
             execution_order.append(1)
-        
+
         @on_app_shutdown
         async def failing_hook():
             execution_order.append("fail")
             raise RuntimeError("Async hook failed")
-        
+
         @on_app_shutdown
         def good_hook2():
             execution_order.append(2)
-        
+
         # Should not raise exception
         await run_shutdown_hooks()
-        
+
         # All hooks should have been attempted
         assert execution_order == [1, "fail", 2]
         assert _lifecycle_state["shutdown_initiated"] is True
-    
+
     @pytest.mark.asyncio
     async def test_shutdown_timeout(self):
         """Test shutdown timeout mechanism."""
-        
+
         @on_app_shutdown
         async def slow_hook():
             await asyncio.sleep(2)  # Simulate slow shutdown
-        
+
         # Set short timeout
         with patch.dict(os.environ, {"AIUI_SHUTDOWN_TIMEOUT": "0.1"}):
             start_time = time.time()
             await run_shutdown_hooks()
             elapsed = time.time() - start_time
-            
+
             # Should timeout quickly
             assert elapsed < 0.5
             assert _lifecycle_state["shutdown_initiated"] is True
-    
+
     @pytest.mark.asyncio
     async def test_startup_idempotent(self):
         """Test that startup hooks are only run once."""
         call_count = 0
-        
+
         @on_app_startup
         def increment_hook():
             nonlocal call_count
             call_count += 1
-        
+
         # Run startup hooks multiple times
         await run_startup_hooks()
         await run_startup_hooks()
         await run_startup_hooks()
-        
+
         # Hook should only be called once
         assert call_count == 1
         assert _lifecycle_state["startup_completed"] is True
-    
+
     @pytest.mark.asyncio
     async def test_shutdown_idempotent(self):
         """Test that shutdown hooks are only run once."""
         call_count = 0
-        
+
         @on_app_shutdown
         def increment_hook():
             nonlocal call_count
             call_count += 1
-        
+
         # Run shutdown hooks multiple times
         await run_shutdown_hooks()
         await run_shutdown_hooks()
         await run_shutdown_hooks()
-        
+
         # Hook should only be called once
         assert call_count == 1
         assert _lifecycle_state["shutdown_initiated"] is True
@@ -286,34 +287,35 @@ class TestLifecycleHooks:
 
 class TestLifecycleState:
     """Test lifecycle state management."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_lifecycle_state()
-    
+
     def test_initial_state(self):
         """Test initial lifecycle state."""
         assert _lifecycle_state["startup_completed"] is False
         assert _lifecycle_state["shutdown_initiated"] is False
         assert _lifecycle_state["startup_time"] == 0
         assert _lifecycle_state["shutdown_time"] == 0
-    
+
     def test_reset_state(self):
         """Test state reset functionality."""
+
         # Add some hooks and change state
         @on_app_startup
         def hook():
             pass
-        
+
         _lifecycle_state["startup_completed"] = True
         _lifecycle_state["startup_time"] = 1.5
-        
+
         assert len(_startup_hooks) == 1
         assert _lifecycle_state["startup_completed"] is True
-        
+
         # Reset state
         reset_lifecycle_state()
-        
+
         # Should be back to initial state
         assert len(_startup_hooks) == 0
         assert _lifecycle_state["startup_completed"] is False
@@ -322,110 +324,114 @@ class TestLifecycleState:
 
 class TestLifecycleIntegration:
     """Integration tests for lifecycle hooks."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_lifecycle_state()
-    
+
     @pytest.mark.asyncio
     async def test_vector_store_example(self):
         """Test the vector store example from the issue."""
         # Simulate a vector store
         vector_store = {"connected": False, "closed": False}
-        
+
         @on_app_startup
         async def warm():
             # Simulate async connection
             await asyncio.sleep(0.01)
             vector_store["connected"] = True
-        
+
         @on_app_shutdown
         async def drain():
             # Simulate async cleanup
             await asyncio.sleep(0.01)
             vector_store["closed"] = True
-        
+
         # Initially not connected
         assert vector_store["connected"] is False
-        
+
         # Run startup
         await run_startup_hooks()
         assert vector_store["connected"] is True
         assert _lifecycle_state["startup_completed"] is True
-        
+
         # Run shutdown
         await run_shutdown_hooks()
         assert vector_store["closed"] is True
         assert _lifecycle_state["shutdown_initiated"] is True
-    
+
     @pytest.mark.asyncio
     async def test_resource_lifecycle(self):
         """Test complete resource lifecycle with startup and shutdown."""
         resource_states = []
-        
+
         class MockResource:
             def __init__(self, name):
                 self.name = name
                 self.initialized = False
                 self.cleaned_up = False
-            
+
             async def initialize(self):
                 resource_states.append(f"{self.name}_init")
                 self.initialized = True
-            
+
             async def cleanup(self):
                 resource_states.append(f"{self.name}_cleanup")
                 self.cleaned_up = True
-        
+
         # Create resources
         db = MockResource("db")
         cache = MockResource("cache")
         queue = MockResource("queue")
-        
+
         # Register startup hooks
         @on_app_startup
         async def init_db():
             await db.initialize()
-        
+
         @on_app_startup
         async def init_cache():
             await cache.initialize()
-        
+
         @on_app_startup
         async def init_queue():
             await queue.initialize()
-        
+
         # Register shutdown hooks (reverse order)
         @on_app_shutdown
         async def cleanup_queue():
             await queue.cleanup()
-        
+
         @on_app_shutdown
         async def cleanup_cache():
             await cache.cleanup()
-        
+
         @on_app_shutdown
         async def cleanup_db():
             await db.cleanup()
-        
+
         # Run lifecycle
         await run_startup_hooks()
-        
+
         # All resources should be initialized
         assert db.initialized
         assert cache.initialized
         assert queue.initialized
-        
+
         await run_shutdown_hooks()
-        
+
         # All resources should be cleaned up
         assert db.cleaned_up
         assert cache.cleaned_up
         assert queue.cleaned_up
-        
+
         # Check execution order
         expected_order = [
-            "db_init", "cache_init", "queue_init",
-            "queue_cleanup", "cache_cleanup", "db_cleanup"
+            "db_init",
+            "cache_init",
+            "queue_init",
+            "queue_cleanup",
+            "cache_cleanup",
+            "db_cleanup",
         ]
         assert resource_states == expected_order

--- a/tests/unit/test_window_message.py
+++ b/tests/unit/test_window_message.py
@@ -1,56 +1,54 @@
 """Tests for window message feature."""
 
 import asyncio
-import json
+
 import pytest
-import time
-from unittest.mock import AsyncMock, Mock, patch
 
 from praisonaiui.features.window_message import (
     WindowMessageFeature,
-    on_window_message,
-    register_window_message_hook,
-    handle_window_message,
-    send_window_message,
-    reset_window_message_state,
-    _window_message_hooks,
     _message_log,
     _session_contexts,
+    _window_message_hooks,
+    handle_window_message,
+    on_window_message,
+    register_window_message_hook,
+    reset_window_message_state,
+    send_window_message,
 )
 
 
 class TestWindowMessageFeature:
     """Test WindowMessageFeature protocol implementation."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     def test_feature_protocol(self):
         """Test that WindowMessageFeature implements BaseFeatureProtocol correctly."""
         feature = WindowMessageFeature()
-        
+
         assert feature.name == "window_message"
         assert feature.description == "Browser window.postMessage communication"
         assert len(feature.routes()) == 5  # Added receive endpoint
         assert len(feature.cli_commands()) == 1
-    
+
     @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """Test health check reports correct state."""
         feature = WindowMessageFeature()
-        
+
         # Add some hooks
         @on_window_message("parent")
         async def parent_hook(data):
             pass
-        
+
         @on_window_message()
         async def wildcard_hook(data):
             pass
-        
+
         health = await feature.health()
-        
+
         assert health["status"] == "ok"
         assert health["feature"] == "window_message"
         assert health["total_hooks"] == 2
@@ -61,130 +59,130 @@ class TestWindowMessageFeature:
 
 class TestWindowMessageHooks:
     """Test window message hook registration and execution."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     def test_hook_registration(self):
         """Test window message hook registration."""
-        
+
         @register_window_message_hook("parent", lambda data: None)
         def parent_hook(data):
             pass
-        
+
         @register_window_message_hook(None, lambda data: None)
         def wildcard_hook(data):
             pass
-        
+
         assert "parent" in _window_message_hooks
         assert "*" in _window_message_hooks
         assert len(_window_message_hooks["parent"]) == 1
         assert len(_window_message_hooks["*"]) == 1
-    
+
     def test_decorator_syntax(self):
         """Test decorator syntax for window message hooks."""
-        
+
         @on_window_message("https://example.com")
         def specific_origin_hook(data):
             pass
-        
+
         @on_window_message()
         def any_origin_hook(data):
             pass
-        
+
         assert "https://example.com" in _window_message_hooks
         assert "*" in _window_message_hooks
         assert len(_window_message_hooks["https://example.com"]) == 1
         assert len(_window_message_hooks["*"]) == 1
-    
+
     @pytest.mark.asyncio
     async def test_message_handling_with_specific_source(self):
         """Test message handling with specific source matching."""
         calls = []
-        
+
         @on_window_message("parent")
         async def parent_hook(data):
             calls.append(("parent", data))
-        
+
         @on_window_message("https://example.com")
         async def example_hook(data):
             calls.append(("example", data))
-        
+
         # Send message from parent
         await handle_window_message({"type": "test", "value": 1}, "parent")
-        
+
         # Send message from example.com
         await handle_window_message({"type": "test", "value": 2}, "https://example.com")
-        
+
         # Send message from unknown source
         await handle_window_message({"type": "test", "value": 3}, "https://other.com")
-        
+
         assert len(calls) == 2
         assert ("parent", {"type": "test", "value": 1}) in calls
         assert ("example", {"type": "test", "value": 2}) in calls
-    
+
     @pytest.mark.asyncio
     async def test_message_handling_with_wildcard(self):
         """Test message handling with wildcard hooks."""
         calls = []
-        
+
         @on_window_message()  # Wildcard
         async def any_hook(data):
             calls.append(data)
-        
+
         # Send messages from different sources
         await handle_window_message({"type": "test1"}, "parent")
         await handle_window_message({"type": "test2"}, "https://example.com")
         await handle_window_message({"type": "test3"}, None)
-        
+
         assert len(calls) == 3
         assert {"type": "test1"} in calls
         assert {"type": "test2"} in calls
         assert {"type": "test3"} in calls
-    
+
     @pytest.mark.asyncio
     async def test_message_handling_with_multiple_hooks(self):
         """Test message handling with multiple matching hooks."""
         calls = []
-        
+
         @on_window_message("parent")
         async def parent_hook1(data):
             calls.append(("parent1", data))
-        
+
         @on_window_message("parent")
         async def parent_hook2(data):
             calls.append(("parent2", data))
-        
+
         @on_window_message()
         async def wildcard_hook(data):
             calls.append(("wildcard", data))
-        
+
         await handle_window_message({"type": "test"}, "parent")
-        
+
         # Should call all matching hooks
         assert len(calls) == 3
         assert ("parent1", {"type": "test"}) in calls
         assert ("parent2", {"type": "test"}) in calls
         assert ("wildcard", {"type": "test"}) in calls
-    
+
     @pytest.mark.asyncio
     async def test_hook_error_handling(self):
         """Test that hook errors don't break message processing."""
         calls = []
-        
+
         @on_window_message("parent")
         async def failing_hook(data):
             calls.append("failing")
             raise RuntimeError("Hook failed")
-        
+
         @on_window_message("parent")
         async def working_hook(data):
             calls.append("working")
-        
+
         # Should not raise exception
         await handle_window_message({"type": "test"}, "parent")
-        
+
         # Both hooks should have been attempted
         assert "failing" in calls
         assert "working" in calls
@@ -192,28 +190,28 @@ class TestWindowMessageHooks:
 
 class TestWindowMessageLogging:
     """Test window message logging functionality."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     @pytest.mark.asyncio
     async def test_inbound_message_logging(self):
         """Test that inbound messages are logged."""
         await handle_window_message({"type": "test"}, "parent")
-        
+
         assert len(_message_log) == 1
         log_entry = _message_log[0]
         assert log_entry["type"] == "window_message_inbound"
         assert log_entry["data"] == {"type": "test"}
         assert log_entry["source"] == "parent"
         assert "timestamp" in log_entry
-    
+
     @pytest.mark.asyncio
     async def test_outbound_message_logging(self):
         """Test that outbound messages are logged."""
         await send_window_message({"type": "response"}, "parent")
-        
+
         assert len(_message_log) == 1
         log_entry = _message_log[0]
         assert log_entry["type"] == "window_message_outbound"
@@ -224,52 +222,52 @@ class TestWindowMessageLogging:
 
 class TestWindowMessageSending:
     """Test window message sending functionality."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     @pytest.mark.asyncio
     async def test_send_to_parent(self):
         """Test sending message to parent window."""
         await send_window_message({"type": "hello", "message": "test"})
-        
+
         assert len(_message_log) == 1
         log_entry = _message_log[0]
         assert log_entry["type"] == "window_message_outbound"
         assert log_entry["data"]["type"] == "hello"
         assert log_entry["target"] == "parent"
-    
+
     @pytest.mark.asyncio
     async def test_send_with_custom_target(self):
         """Test sending message with custom target."""
         await send_window_message({"type": "hello"}, "https://example.com")
-        
+
         assert len(_message_log) == 1
         log_entry = _message_log[0]
         assert log_entry["target"] == "https://example.com"
-    
+
     @pytest.mark.asyncio
     async def test_send_with_invalid_target(self):
         """Test sending message with invalid target is rejected."""
         await send_window_message({"type": "hello"}, "invalid-target")
-        
+
         # Message should not be logged if target is invalid
         assert len(_message_log) == 0
-    
+
     @pytest.mark.asyncio
     async def test_send_with_session_context(self):
         """Test sending message with active session context."""
         # Mock session context with SSE queue
         sse_queue = asyncio.Queue()
-        
+
         # Add a session context for testing
         test_session_id = "test_session"
         _session_contexts[test_session_id] = {"sse_queue": sse_queue}
-        
+
         try:
             await send_window_message({"type": "test"}, "parent")
-            
+
             # Should have queued message for SSE
             assert not sse_queue.empty()
             message = await sse_queue.get()
@@ -284,76 +282,76 @@ class TestWindowMessageSending:
 
 class TestWindowMessageSecurity:
     """Test window message security features."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     @pytest.mark.asyncio
     async def test_origin_filtering(self):
         """Test that hooks can filter by origin."""
         calls = []
-        
+
         @on_window_message("https://trusted.com")
         async def trusted_hook(data):
             calls.append("trusted")
-        
+
         @on_window_message("https://evil.com")
         async def evil_hook(data):
             calls.append("evil")
-        
+
         # Send from trusted origin
         await handle_window_message({"type": "test"}, "https://trusted.com")
         assert calls == ["trusted"]
-        
+
         calls.clear()
-        
+
         # Send from evil origin
         await handle_window_message({"type": "test"}, "https://evil.com")
         assert calls == ["evil"]
-        
+
         calls.clear()
-        
+
         # Send from unknown origin
         await handle_window_message({"type": "test"}, "https://unknown.com")
         assert calls == []  # No hooks should be called
-    
+
     @pytest.mark.asyncio
     async def test_target_validation_in_send(self):
         """Test target validation in send_window_message."""
         valid_targets = ["parent", "*", "https://example.com", "http://localhost:3000"]
         invalid_targets = ["javascript:alert(1)", "data:text/html", "file:///etc/passwd"]
-        
+
         for target in valid_targets:
             await send_window_message({"type": "test"}, target)
-        
+
         # Should have logged valid messages
         valid_count = len([t for t in valid_targets if t not in ["javascript:alert(1)"]])
         assert len(_message_log) == len(valid_targets)
-        
+
         # Reset log
         _message_log.clear()
-        
+
         for target in invalid_targets:
             await send_window_message({"type": "test"}, target)
-        
+
         # Should not have logged invalid messages
         assert len(_message_log) == 0
 
 
 class TestWindowMessageIntegration:
     """Integration tests for window message feature."""
-    
+
     def setup_method(self):
         """Reset state before each test."""
         reset_window_message_state()
-    
+
     @pytest.mark.asyncio
     async def test_user_context_example(self):
         """Test the user context example from the issue."""
         user_context = {}
         response_sent = {}
-        
+
         @on_window_message("parent")
         async def on_msg(data):
             if data.get("type") == "set_user":
@@ -361,71 +359,58 @@ class TestWindowMessageIntegration:
                 # Simulate sending response
                 response_sent["type"] = "user_set"
                 response_sent["ok"] = True
-        
+
         # Simulate receiving user context message
-        await handle_window_message({
-            "type": "set_user",
-            "email": "user@example.com"
-        }, "parent")
-        
+        await handle_window_message({"type": "set_user", "email": "user@example.com"}, "parent")
+
         assert user_context["email"] == "user@example.com"
         assert response_sent["type"] == "user_set"
         assert response_sent["ok"] is True
-    
+
     @pytest.mark.asyncio
     async def test_bidirectional_communication(self):
         """Test bidirectional communication between iframe and parent."""
         received_messages = []
-        
+
         @on_window_message("parent")
         async def handle_parent_message(data):
             received_messages.append(data)
-            
+
             # Send acknowledgment
-            await send_window_message({
-                "type": "ack",
-                "received": data["type"]
-            }, "parent")
-        
+            await send_window_message({"type": "ack", "received": data["type"]}, "parent")
+
         # Simulate receiving message from parent
-        await handle_window_message({
-            "type": "config_update",
-            "theme": "dark"
-        }, "parent")
-        
+        await handle_window_message({"type": "config_update", "theme": "dark"}, "parent")
+
         # Check message was received
         assert len(received_messages) == 1
         assert received_messages[0]["type"] == "config_update"
         assert received_messages[0]["theme"] == "dark"
-        
+
         # Check acknowledgment was sent
         outbound_logs = [log for log in _message_log if log["type"] == "window_message_outbound"]
         assert len(outbound_logs) == 1
         assert outbound_logs[0]["data"]["type"] == "ack"
         assert outbound_logs[0]["data"]["received"] == "config_update"
-    
+
     @pytest.mark.asyncio
     async def test_multiple_iframe_sources(self):
         """Test handling messages from multiple iframe sources."""
         messages_by_source = {}
-        
+
         @on_window_message()
         async def handle_any_message(data):
             source = data.get("source", "unknown")
             if source not in messages_by_source:
                 messages_by_source[source] = []
             messages_by_source[source].append(data)
-        
+
         # Simulate messages from different sources
         sources = ["parent", "https://widget1.com", "https://widget2.com"]
-        
+
         for i, source in enumerate(sources):
-            await handle_window_message({
-                "type": "status",
-                "source": source,
-                "id": i
-            }, source)
-        
+            await handle_window_message({"type": "status", "source": source, "id": i}, source)
+
         # Check all messages were received
         assert len(messages_by_source) == len(sources)
         for source in sources:


### PR DESCRIPTION
Fixes #37

## Summary

Ran ruff --fix over the test files added by PR #34 to clean up 307 cosmetic linting errors (W293 trailing whitespace, F401 unused imports, W292 missing EOL). Also formatted 2 files for consistency.

## Before / After

```bash
# Before
ruff check tests/unit/test_audio_hooks.py tests/unit/test_lifecycle.py tests/unit/test_window_message.py
# Found 307 errors

# After
ruff check tests/unit/test_audio_hooks.py tests/unit/test_lifecycle.py tests/unit/test_window_message.py
# All checks passed!
```

## Acceptance criteria

- ✅ `ruff check <those 6 files>` exits 0
- ✅ All 56 tests in the target files still pass
- ✅ Import time of `praisonaiui` stays under 200 ms (165.7ms)
- ✅ No behavioural change

## Test evidence

```
============================= test session starts ==============================
================================ 56 passed in 3.09s ==============================
```

## Import-time proof

```
165.7ms modules=263 leaked=[]
```

Generated with [Claude Code](https://claude.ai/code)