### PR TITLE
feat(api): PraisonAIUI-native public names (non-developer-friendly)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui"
-version = "0.3.111"
+version = "0.3.112"
 description = "YAML-driven website generator - CLI and compiler"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/praisonaiui/__init__.py
+++ b/src/praisonaiui/__init__.py
@@ -46,15 +46,25 @@ def __getattr__(name: str):
     _lifecycle_attrs = {
         "on_app_startup",
         "on_app_shutdown",
+        # PraisonAIUI-native aliases
+        "on_startup",
+        "on_shutdown",
     }
     _window_message_attrs = {
         "on_window_message",
         "send_window_message",
+        # PraisonAIUI-native aliases
+        "on_parent_message",
+        "send_to_parent",
     }
     _audio_attrs = {
         "on_audio_start",
         "on_audio_chunk",
         "on_audio_end",
+        # PraisonAIUI-native aliases
+        "on_mic_start",
+        "on_mic_data",
+        "on_mic_stop",
     }
     _message_attrs = {
         "Message",
@@ -68,6 +78,11 @@ def __getattr__(name: str):
         "AskActionMessage",
         "AskElementMessage",
         "ErrorMessage",
+        # PraisonAIUI-native aliases (noun-first, API-direction compliant)
+        "TextPrompt",
+        "FilePrompt",
+        "ChoicePrompt",
+        "LocationPrompt",
     }
     _sync_attrs = {"make_async", "run_sync", "AsyncContext"}
     _utils_attrs = {"sleep", "format_duration", "truncate_text", "safe_filename"}
@@ -92,6 +107,14 @@ def __getattr__(name: str):
         "get_copilot_functions",
         "get_copilot_function",
         "call_copilot_function",
+        # PraisonAIUI-native aliases
+        "UIFunction",
+        "UIFunctionParameter",
+        "ui_function",
+        "on_ui_function",
+        "call_ui_function",
+        "get_ui_function",
+        "get_ui_functions",
     }
     _chat_settings_attrs = {
         "ChatSettings",
@@ -105,6 +128,9 @@ def __getattr__(name: str):
         "trigger_settings_update",
         "create_model_settings",
         "create_ui_settings",
+        # PraisonAIUI-native aliases
+        "Settings",
+        "on_settings_change",
     }
     _mcp_attrs = {
         "MCPServer",
@@ -115,6 +141,8 @@ def __getattr__(name: str):
         "current_channel",
         "current_user",
         "on_slack_reaction_added",
+        # PraisonAIUI-native alias
+        "on_slack_reaction",
     }
     _auth_attrs = {
         "oauth_callback",
@@ -124,6 +152,11 @@ def __getattr__(name: str):
         "User",
         "Session",
         "on_shared_thread_view",
+        # PraisonAIUI-native aliases
+        "on_oauth_login",
+        "on_header_login",
+        "on_password_login",
+        "on_shared_view",
     }
     _usage_attrs = {"get_token_usage"}
     _instrumentation_attrs = {
@@ -278,7 +311,7 @@ def __getattr__(name: str):
 
         return getattr(platform_adapters, name)
     if name in _auth_attrs:
-        if name == "on_shared_thread_view":
+        if name in ("on_shared_thread_view", "on_shared_view"):
             from praisonaiui.features import sharing
 
             return getattr(sharing, name)
@@ -523,6 +556,35 @@ __all__ = [
     "no_instrument",
     # Usage tracking
     "get_token_usage",
+    # ── PraisonAIUI-native, non-developer-friendly names ────────────
+    # Shorter, plain-English aliases for the symbols above.  Use these
+    # in new code; the original names remain importable for backward
+    # compatibility.
+    "TextPrompt",
+    "FilePrompt",
+    "ChoicePrompt",
+    "LocationPrompt",
+    "UIFunction",
+    "UIFunctionParameter",
+    "ui_function",
+    "on_ui_function",
+    "call_ui_function",
+    "get_ui_function",
+    "get_ui_functions",
+    "Settings",
+    "on_settings_change",
+    "on_oauth_login",
+    "on_header_login",
+    "on_password_login",
+    "on_shared_view",
+    "on_slack_reaction",
+    "on_startup",
+    "on_shutdown",
+    "on_parent_message",
+    "send_to_parent",
+    "on_mic_start",
+    "on_mic_data",
+    "on_mic_stop",
     # Feature protocol
     "BaseFeatureProtocol",
     "register_feature",

--- a/src/praisonaiui/__version__.py
+++ b/src/praisonaiui/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.3.110"
+__version__ = "0.3.112"

--- a/src/praisonaiui/auth.py
+++ b/src/praisonaiui/auth.py
@@ -641,3 +641,13 @@ class TokenQueryMiddleware:
         else:
             response = HTMLResponse(_LOGIN_FORM_HTML, status_code=401)
         await response(scope, receive, send)
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# "on_*" verb form reads as "do this when …" which is far clearer to
+# non-developers than the "*_callback" suffix.  Original names remain
+# importable for backward compatibility.
+
+on_oauth_login = oauth_callback
+on_header_login = header_auth_callback
+on_password_login = password_auth_callback

--- a/src/praisonaiui/chat_settings.py
+++ b/src/praisonaiui/chat_settings.py
@@ -296,3 +296,16 @@ def create_ui_settings() -> ChatSettings:
         title="UI Settings",
         description="Configure the user interface",
     )
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# Plain-English names. ``Settings`` is easier for non-developers than
+# ``ChatSettings`` (a settings panel is just a settings panel).  The
+# "change" verb reads more naturally than "update" for UI form events.
+
+Settings = ChatSettings
+
+
+def on_settings_change(func):
+    """Alias for :func:`on_settings_update` using plain-English verb."""
+    return on_settings_update(func)

--- a/src/praisonaiui/copilot.py
+++ b/src/praisonaiui/copilot.py
@@ -250,3 +250,17 @@ async def show_notification(
 ) -> Dict[str, Any]:
     """Show a notification (implemented in frontend)."""
     return {"action": "show_notification", "message": message, "type": type, "duration": duration}
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# Non-developer-friendly names. The "UI function" phrasing communicates
+# "a function the UI can call" without borrowing external product vocabulary.
+# The old names above remain importable for backward compatibility.
+
+UIFunction = CopilotFunction
+UIFunctionParameter = CopilotFunctionParameter
+ui_function = copilot_function
+on_ui_function = on_copilot_function_call
+call_ui_function = call_copilot_function
+get_ui_function = get_copilot_function
+get_ui_functions = get_copilot_functions

--- a/src/praisonaiui/features/audio.py
+++ b/src/praisonaiui/features/audio.py
@@ -417,3 +417,12 @@ def on_audio_end(func: Callable) -> Callable:
             await handler(aiui.InboundMessage(content=transcript, source="voice"))
     """
     return register_audio_end_hook(func)
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# "mic" is what non-developers call the microphone; "audio" is correct
+# but more abstract.  "data" is friendlier than "chunk" for a lay reader.
+
+on_mic_start = on_audio_start
+on_mic_data = on_audio_chunk
+on_mic_stop = on_audio_end

--- a/src/praisonaiui/features/lifecycle.py
+++ b/src/praisonaiui/features/lifecycle.py
@@ -283,3 +283,11 @@ def on_app_shutdown(func: Callable) -> Callable:
             await vector_store.close()
     """
     return register_shutdown_hook(func)
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# Drop the "app_" prefix — it's implied by context (you're obviously
+# registering hooks on *this* app).
+
+on_startup = on_app_startup
+on_shutdown = on_app_shutdown

--- a/src/praisonaiui/features/platform_adapters/__init__.py
+++ b/src/praisonaiui/features/platform_adapters/__init__.py
@@ -23,12 +23,13 @@ __all__ = [
     "current_user",
     "channel_context",
     "on_slack_reaction_added",
+    "on_slack_reaction",  # PraisonAIUI-native alias (shorter, plain-English)
 ]
 
 
 def __getattr__(name: str):
     """Lazy import platform-specific functionality."""
-    if name == "on_slack_reaction_added":
+    if name in ("on_slack_reaction_added", "on_slack_reaction"):
         from .slack import on_slack_reaction_added
 
         return on_slack_reaction_added

--- a/src/praisonaiui/features/sharing.py
+++ b/src/praisonaiui/features/sharing.py
@@ -159,3 +159,8 @@ def get_share_url(token: str, base_url: str = "") -> str:
     """
     base_url = base_url.rstrip("/")
     return f"{base_url}/shared/{token}"
+
+
+# ── PraisonAIUI-native alias ──────────────────────────────────────
+# Shorter, plainer-English verb form.
+on_shared_view = on_shared_thread_view

--- a/src/praisonaiui/features/window_message.py
+++ b/src/praisonaiui/features/window_message.py
@@ -352,3 +352,11 @@ def on_window_message(source: Optional[str] = None) -> Callable:
         return register_window_message_hook(source, func)
 
     return decorator
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# "parent" is what non-developers call the page that embeds the chat.
+# "window" is technical jargon from the browser postMessage API.
+
+on_parent_message = on_window_message
+send_to_parent = send_window_message

--- a/src/praisonaiui/message.py
+++ b/src/praisonaiui/message.py
@@ -930,3 +930,16 @@ class AskElementMessage:
             return None
         finally:
             self._context._pending_asks.pop(self._id, None)
+
+
+# ── PraisonAIUI-native aliases ──────────────────────────────────────
+# Noun-first, plain-English names that pair with the verb-first
+# ``aiui.prompt()`` helper (see issue #41 API-direction policy).
+# A non-developer reads ``FilePrompt`` as "a prompt that asks for a
+# file" — no "Message" suffix convention required.  The original
+# ``Ask*Message`` names remain importable for backward compatibility.
+
+TextPrompt = AskUserMessage
+FilePrompt = AskFileMessage
+ChoicePrompt = AskActionMessage
+LocationPrompt = AskElementMessage

--- a/tests/unit/test_native_naming.py
+++ b/tests/unit/test_native_naming.py
@@ -1,0 +1,142 @@
+"""Tests for PraisonAIUI-native public API names (non-developer-friendly).
+
+These names are shorter, plain-English aliases for symbols we inherited
+from the broader agent-UI ecosystem. The aliases resolve to *the exact
+same objects* so both names behave identically at runtime. Users should
+prefer the native names in new code; the originals remain supported.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import praisonaiui as aiui
+
+# ── Ask* message family ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "new_name, old_name",
+    [
+        ("TextPrompt", "AskUserMessage"),
+        ("FilePrompt", "AskFileMessage"),
+        ("ChoicePrompt", "AskActionMessage"),
+        ("LocationPrompt", "AskElementMessage"),
+    ],
+)
+def test_prompt_family_native_aliases(new_name: str, old_name: str) -> None:
+    assert getattr(aiui, new_name) is getattr(aiui, old_name)
+
+
+# ── UI / browser-callable functions ─────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "new_name, old_name",
+    [
+        ("UIFunction", "CopilotFunction"),
+        ("UIFunctionParameter", "CopilotFunctionParameter"),
+        ("ui_function", "copilot_function"),
+        ("on_ui_function", "on_copilot_function_call"),
+        ("call_ui_function", "call_copilot_function"),
+        ("get_ui_function", "get_copilot_function"),
+        ("get_ui_functions", "get_copilot_functions"),
+    ],
+)
+def test_ui_function_native_aliases(new_name: str, old_name: str) -> None:
+    # UIFunctionParameter isn't re-exported at aiui top-level; check module
+    if new_name == "UIFunctionParameter":
+        from praisonaiui import copilot
+
+        assert getattr(copilot, new_name) is getattr(copilot, old_name)
+        return
+    assert getattr(aiui, new_name) is getattr(aiui, old_name)
+
+
+# ── Settings ────────────────────────────────────────────────────────
+
+
+def test_settings_alias() -> None:
+    assert aiui.Settings is aiui.ChatSettings
+
+
+def test_on_settings_change_is_callable_decorator() -> None:
+    @aiui.on_settings_change
+    def handler(payload: dict) -> None:
+        pass
+
+    # Should register under the same underlying callback registry as the
+    # legacy name
+    from praisonaiui.chat_settings import get_settings_handlers
+
+    assert handler in get_settings_handlers()
+
+
+# ── Auth callbacks ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "new_name, old_name",
+    [
+        ("on_oauth_login", "oauth_callback"),
+        ("on_header_login", "header_auth_callback"),
+        ("on_password_login", "password_auth_callback"),
+        ("on_shared_view", "on_shared_thread_view"),
+    ],
+)
+def test_auth_native_aliases(new_name: str, old_name: str) -> None:
+    assert getattr(aiui, new_name) is getattr(aiui, old_name)
+
+
+# ── Lifecycle / window / audio / slack ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "new_name, old_name",
+    [
+        ("on_startup", "on_app_startup"),
+        ("on_shutdown", "on_app_shutdown"),
+        ("on_parent_message", "on_window_message"),
+        ("send_to_parent", "send_window_message"),
+        ("on_mic_start", "on_audio_start"),
+        ("on_mic_data", "on_audio_chunk"),
+        ("on_mic_stop", "on_audio_end"),
+        ("on_slack_reaction", "on_slack_reaction_added"),
+    ],
+)
+def test_event_hook_native_aliases(new_name: str, old_name: str) -> None:
+    assert getattr(aiui, new_name) is getattr(aiui, old_name)
+
+
+# ── Public surface advertises the native names ──────────────────────
+
+
+def test_native_names_in_dunder_all() -> None:
+    expected = {
+        "TextPrompt",
+        "FilePrompt",
+        "ChoicePrompt",
+        "LocationPrompt",
+        "UIFunction",
+        "ui_function",
+        "on_ui_function",
+        "call_ui_function",
+        "get_ui_function",
+        "get_ui_functions",
+        "Settings",
+        "on_settings_change",
+        "on_oauth_login",
+        "on_header_login",
+        "on_password_login",
+        "on_shared_view",
+        "on_slack_reaction",
+        "on_startup",
+        "on_shutdown",
+        "on_parent_message",
+        "send_to_parent",
+        "on_mic_start",
+        "on_mic_data",
+        "on_mic_stop",
+    }
+    missing = expected - set(aiui.__all__)
+    assert not missing, f"Missing from __all__: {sorted(missing)}"


### PR DESCRIPTION
feat(api): PraisonAIUI-native public names (non-developer-friendly) (closes #41)

Establishes a plain-English, noun-first public API surface that does not
lift names from unrelated frameworks.  Every original name remains
importable as a silent alias so no existing code breaks.

## Rationale
1. **Non-developer friendly** — a lay reader should understand what a
   symbol does from its name alone (``FilePrompt`` > ``AskFileMessage``,
   ``on_startup`` > ``on_app_startup``, ``on_mic_start`` > ``on_audio_start``).
2. **API-direction compliant** — new class aliases are *noun-first*,
   not verb-first, so they pass the regression fence added in PR #44
   (``tests/unit/test_api_direction.py``).
3. **No overlap with third-party frameworks** — the pre-rename audit
   showed ~25 public names that read as direct lifts.  These now have
   native replacements.

## Native aliases (new primary names)

| Native (new)          | Legacy (still supported)        |
|-----------------------|---------------------------------|
| TextPrompt            | AskUserMessage                  |
| FilePrompt            | AskFileMessage                  |
| ChoicePrompt          | AskActionMessage                |
| LocationPrompt        | AskElementMessage               |
| UIFunction            | CopilotFunction                 |
| UIFunctionParameter   | CopilotFunctionParameter        |
| ui_function           | copilot_function                |
| on_ui_function        | on_copilot_function_call        |
| call_ui_function      | call_copilot_function           |
| get_ui_function(s)    | get_copilot_function(s)         |
| Settings              | ChatSettings                    |
| on_settings_change    | on_settings_update              |
| on_oauth_login        | oauth_callback                  |
| on_header_login       | header_auth_callback            |
| on_password_login     | password_auth_callback          |
| on_shared_view        | on_shared_thread_view           |
| on_slack_reaction     | on_slack_reaction_added         |
| on_startup            | on_app_startup                  |
| on_shutdown           | on_app_shutdown                 |
| on_parent_message     | on_window_message               |
| send_to_parent        | send_window_message             |
| on_mic_start          | on_audio_start                  |
| on_mic_data           | on_audio_chunk                  |
| on_mic_stop           | on_audio_end                    |

Generic agent/Python vocabulary (``Message``, ``User``, ``Task``,
``Step``, ``Action``, ``ErrorMessage``, ``CustomElement``, ``sleep``,
``make_async``, ``run_sync``, ``Plotly``, ``Pyplot``, ``Dataframe``,
``instrument_openai``, ``on_mcp_connect``) is kept as-is — these are
industry-standard terms, not lifts.

## Tests
- ``tests/unit/test_native_naming.py`` — 26 new tests proving each
  new name resolves to the exact same object as its legacy counterpart
  and is exported in ``praisonaiui.__all__``.

Full suite: **940 pass**, 4 skipped, 8 xfailed, 1 xpassed.

## Version
Bumps to 0.3.112; fixes a pre-existing mismatch where ``pyproject.toml``
advertised 0.3.111 while ``__version__.py`` still said 0.3.110.
