### PR TITLE
refactor(api): PraisonAI-native names for discovery, citations, reasoning types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aiui"
-version = "0.3.113"
+version = "0.3.114"
 description = "YAML-driven website generator - CLI and compiler"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/praisonaiui/__init__.py
+++ b/src/praisonaiui/__init__.py
@@ -201,15 +201,15 @@ def __getattr__(name: str):
         "BaseProvider",
         "RunEvent",
         "RunEventType",
-        # Discovery schema (Issue #48)
-        "ModelInfo",
-        "AgentDetails",
-        "TeamDetails",
-        # RAG citations (Issue #49)
-        "Reference",
-        "ReferenceData",
-        # Rich reasoning (Issue #50)
-        "ReasoningStep",
+        # Discovery cards (Issue #48) — PraisonAI-native names
+        "ModelCard",
+        "AgentCard",
+        "TeamCard",
+        # RAG source chunks (Issue #49) — PraisonAI-native names
+        "SourceChunk",
+        "SourceBundle",
+        # Rich reasoning (Issue #50) — PraisonAI-native name
+        "ThoughtStep",
     }
     _providers_attrs = {"PraisonAIProvider"}
     _config_attrs = {"configure"}
@@ -488,12 +488,13 @@ __all__ = [
     "RunEventType",
     "PraisonAIProvider",
     # Discovery, citations, reasoning schema (Issues #48, #49, #50)
-    "ModelInfo",
-    "AgentDetails",
-    "TeamDetails",
-    "Reference",
-    "ReferenceData",
-    "ReasoningStep",
+    # PraisonAI-native, noun-first names (not lifted from any external framework)
+    "ModelCard",
+    "AgentCard",
+    "TeamCard",
+    "SourceChunk",
+    "SourceBundle",
+    "ThoughtStep",
     # Configuration
     "configure",
     # Action classes and decorators

--- a/src/praisonaiui/__version__.py
+++ b/src/praisonaiui/__version__.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.3.113"
+__version__ = "0.3.114"

--- a/src/praisonaiui/provider.py
+++ b/src/praisonaiui/provider.py
@@ -93,8 +93,12 @@ class RunEventType(str, Enum):
 
 
 @dataclass
-class ModelInfo:
-    """Model / provider info advertised by an agent or team (Issue #48)."""
+class ModelCard:
+    """Model / provider info advertised by an agent or team (Issue #48).
+
+    PraisonAI-native, non-developer-friendly name: a "card" is the small
+    info block a UI shows next to an agent.
+    """
 
     name: str
     model: str
@@ -105,13 +109,13 @@ class ModelInfo:
 
 
 @dataclass
-class AgentDetails:
-    """Standard agent-discovery schema for third-party chat frontends (Issue #48)."""
+class AgentCard:
+    """Agent discovery card — what a chat frontend shows in its picker (Issue #48)."""
 
     agent_id: str
     name: str
     description: str = ""
-    model: Optional[ModelInfo] = None
+    model: Optional[ModelCard] = None
     storage: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
@@ -127,13 +131,13 @@ class AgentDetails:
 
 
 @dataclass
-class TeamDetails:
-    """Standard team-discovery schema (Issue #48)."""
+class TeamCard:
+    """Team discovery card — what a chat frontend shows for multi-agent teams (Issue #48)."""
 
     team_id: str
     name: str
     description: str = ""
-    model: Optional[ModelInfo] = None
+    model: Optional[ModelCard] = None
     storage: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
@@ -149,8 +153,12 @@ class TeamDetails:
 
 
 @dataclass
-class Reference:
-    """A single RAG retrieval chunk cited by an answer (Issue #49)."""
+class SourceChunk:
+    """A single RAG retrieval chunk cited by an answer (Issue #49).
+
+    PraisonAI-native name — "source chunk" is the plain-English term a
+    non-developer would use for "a piece of a source document that was used".
+    """
 
     name: str
     content: str
@@ -167,17 +175,22 @@ class Reference:
 
 
 @dataclass
-class ReferenceData:
-    """A retrieval batch: a query and the chunks it returned (Issue #49)."""
+class SourceBundle:
+    """A bundle of source chunks retrieved for one query (Issue #49).
+
+    Wire format keeps the industry-standard ``references`` JSON key so
+    third-party frontends see the expected shape; only the Python class
+    name is PraisonAI-native.
+    """
 
     query: str
-    references: List[Reference] = field(default_factory=list)
+    chunks: List[SourceChunk] = field(default_factory=list)
     time_ms: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {
             "query": self.query,
-            "references": [r.to_dict() for r in self.references],
+            "references": [c.to_dict() for c in self.chunks],
         }
         if self.time_ms is not None:
             d["time_ms"] = self.time_ms
@@ -185,11 +198,13 @@ class ReferenceData:
 
 
 @dataclass
-class ReasoningStep:
+class ThoughtStep:
     """Structured reasoning-step payload (Issue #50).
 
-    All fields beyond ``title`` are optional so providers can adopt the richer
-    schema incrementally without breaking existing behaviour.
+    PraisonAI-native name — pairs with the existing ``ThinkingSteps`` UI
+    component.  All fields beyond ``title`` are optional so providers can
+    adopt the richer schema incrementally without breaking existing
+    behaviour.
     """
 
     title: str
@@ -400,22 +415,22 @@ class BaseProvider(ABC):
     # -----------------------------------------------------------------
 
     @staticmethod
-    def references_event(
-        query: str,
-        references: List["Reference"],
-        time_ms: Optional[float] = None,
-    ) -> RunEvent:
-        """Build a ``REFERENCES`` event from a ``Reference`` list (Issue #49)."""
+    def source_bundle_event(bundle: "SourceBundle") -> RunEvent:
+        """Build a ``REFERENCES`` event from a ``SourceBundle`` (Issue #49).
+
+        The wire ``type`` stays ``references`` for third-party frontend
+        compatibility; only the Python-side helper name is PraisonAI-native.
+        """
         return RunEvent(
             type=RunEventType.REFERENCES,
-            query=query,
-            references=[r.to_dict() for r in references],
-            time_ms=time_ms,
+            query=bundle.query,
+            references=[c.to_dict() for c in bundle.chunks],
+            time_ms=bundle.time_ms,
         )
 
     @staticmethod
-    def reasoning_step_event(step: "ReasoningStep") -> RunEvent:
-        """Build a ``REASONING_STEP`` event from a structured step (Issue #50)."""
+    def thought_step_event(step: "ThoughtStep") -> RunEvent:
+        """Build a ``REASONING_STEP`` event from a ``ThoughtStep`` (Issue #50)."""
         return RunEvent(
             type=RunEventType.REASONING_STEP,
             step=step.title,

--- a/tests/unit/test_protocol_parity.py
+++ b/tests/unit/test_protocol_parity.py
@@ -2,8 +2,8 @@
 
 Covers:
 - Enriched /agents response + /teams REST surface (#48)
-- RAG ``REFERENCES`` event + ``Reference`` / ``ReferenceData`` (#49)
-- Rich ``ReasoningStep`` schema + ``reasoning_step_event`` helper (#50)
+- RAG ``REFERENCES`` event + ``SourceChunk`` / ``SourceBundle`` (#49)
+- Rich ``ThoughtStep`` schema + ``thought_step_event`` helper (#50)
 
 The tests run against the ASGI app built by ``praisonaiui.build_app()`` so
 route wiring, schema serialisation, and provider delegation are verified
@@ -17,7 +17,6 @@ from starlette.testclient import TestClient
 
 import praisonaiui as aiui
 from praisonaiui.provider import BaseProvider, RunEvent, RunEventType
-
 
 # ── Fixtures ────────────────────────────────────────────────────────
 
@@ -112,30 +111,32 @@ def test_teams_route_delete_endpoint_registered(client):
 # ── Issue #49: references (RAG citations) ───────────────────────────
 
 
-def test_reference_dataclass_round_trip():
-    r = aiui.Reference(name="doc.md", content="x", chunk=3, chunk_size=400)
+def test_source_chunk_round_trip():
+    r = aiui.SourceChunk(name="doc.md", content="x", chunk=3, chunk_size=400)
     d = r.to_dict()
     assert d == {"name": "doc.md", "content": "x", "chunk": 3, "chunk_size": 400}
 
 
-def test_reference_data_round_trip():
-    rd = aiui.ReferenceData(
+def test_source_bundle_round_trip():
+    b = aiui.SourceBundle(
         query="what is x",
-        references=[aiui.Reference(name="a.md", content="alpha")],
+        chunks=[aiui.SourceChunk(name="a.md", content="alpha")],
         time_ms=12.0,
     )
-    d = rd.to_dict()
+    d = b.to_dict()
     assert d["query"] == "what is x"
     assert d["time_ms"] == 12.0
+    # Wire key stays "references" for third-party frontend compatibility
     assert d["references"][0]["name"] == "a.md"
 
 
-def test_references_event_helper():
-    ev = BaseProvider.references_event(
+def test_source_bundle_event_helper():
+    bundle = aiui.SourceBundle(
         query="q",
-        references=[aiui.Reference(name="a.md", content="alpha", chunk=1, chunk_size=50)],
+        chunks=[aiui.SourceChunk(name="a.md", content="alpha", chunk=1, chunk_size=50)],
         time_ms=8.5,
     )
+    ev = BaseProvider.source_bundle_event(bundle)
     assert ev.type is RunEventType.REFERENCES
     payload = ev.to_dict()
     assert payload["type"] == "references"
@@ -151,8 +152,8 @@ def test_references_enum_value_is_stable():
 # ── Issue #50: rich reasoning step ──────────────────────────────────
 
 
-def test_reasoning_step_optional_fields_omitted_when_absent():
-    s = aiui.ReasoningStep(title="plan")
+def test_thought_step_optional_fields_omitted_when_absent():
+    s = aiui.ThoughtStep(title="plan")
     d = s.to_dict()
     # Optional fields stay out of the dict entirely when None
     assert "action" not in d
@@ -161,8 +162,8 @@ def test_reasoning_step_optional_fields_omitted_when_absent():
     assert d["title"] == "plan"
 
 
-def test_reasoning_step_full_fields():
-    s = aiui.ReasoningStep(
+def test_thought_step_full_fields():
+    s = aiui.ThoughtStep(
         title="search",
         result="found 3 refs",
         reasoning="because the query was specific",
@@ -181,9 +182,9 @@ def test_reasoning_step_full_fields():
     }
 
 
-def test_reasoning_step_event_helper_carries_fields():
-    step = aiui.ReasoningStep(title="plan", confidence=0.9, action="plan")
-    ev = BaseProvider.reasoning_step_event(step)
+def test_thought_step_event_helper_carries_fields():
+    step = aiui.ThoughtStep(title="plan", confidence=0.9, action="plan")
+    ev = BaseProvider.thought_step_event(step)
     assert ev.type is RunEventType.REASONING_STEP
     d = ev.to_dict()
     assert d["step"] == "plan"
@@ -207,6 +208,20 @@ def test_runevent_backcompat_unstructured_step_still_works():
 
 def test_new_symbols_in_dunder_all():
     expected = {
+        "ModelCard",
+        "AgentCard",
+        "TeamCard",
+        "SourceChunk",
+        "SourceBundle",
+        "ThoughtStep",
+    }
+    missing = expected - set(aiui.__all__)
+    assert not missing, f"Missing from __all__: {sorted(missing)}"
+
+
+def test_no_competitor_lifted_names_exported():
+    """Guard rail: PraisonAIUI must not re-export competitor-lifted type names."""
+    lifted = {
         "ModelInfo",
         "AgentDetails",
         "TeamDetails",
@@ -214,5 +229,9 @@ def test_new_symbols_in_dunder_all():
         "ReferenceData",
         "ReasoningStep",
     }
-    missing = expected - set(aiui.__all__)
-    assert not missing, f"Missing from __all__: {sorted(missing)}"
+    leaked = [n for n in lifted if hasattr(aiui, n)]
+    assert not leaked, (
+        f"PraisonAIUI leaked competitor-lifted names: {leaked}. "
+        "Use the PraisonAI-native ModelCard/AgentCard/TeamCard/SourceChunk/"
+        "SourceBundle/ThoughtStep instead."
+    )


### PR DESCRIPTION
refactor(api): PraisonAI-native names for discovery, citations, reasoning types

Rename the six public dataclasses shipped in v0.3.113 so none of them are
exact-name lifts from an external framework.  Names are now PraisonAI-unique,
noun-first, non-developer-friendly, and pair with the existing ``*Prompt`` /
``ThinkingSteps`` PraisonAI style.

## Rename table

| v0.3.113 (lifted) | v0.3.114 (PraisonAI-native) |
|-------------------|-----------------------------|
| ModelInfo         | **ModelCard**               |
| AgentDetails      | **AgentCard**               |
| TeamDetails       | **TeamCard**                |
| Reference         | **SourceChunk**             |
| ReferenceData     | **SourceBundle**            |
| ReasoningStep     | **ThoughtStep**             |
| `references_event()`     | **`source_bundle_event()`** |
| `reasoning_step_event()` | **`thought_step_event()`**  |

## What stays the same

- **Wire format is unchanged.**  The SSE event ``type`` string is still
  ``"references"``, and the JSON payload still uses the keys ``query``,
  ``references``, ``time_ms`` so third-party chat frontends see the exact
  shape they expect.
- ``RunEvent`` and ``RunEventType`` keep their existing names — these
  pre-existed in PraisonAIUI before the competitor audit and are not lifts.
- ``RunEventType.REFERENCES = "references"`` enum variant is unchanged.
- All REST routes added in v0.3.113 are unchanged (``/teams``, etc.).

## Why a breaking rename (no aliases)

Keeping the lifted names even as silent aliases would defeat the stated
goal ("names unique for PraisonAI").  v0.3.113 was released <1 h before
this rename, so no external consumer can have taken a dependency yet.

## Tests

- Every existing test in ``tests/unit/test_protocol_parity.py`` updated
  to the new names — **all 15 pass**.
- **New regression guard** ``test_no_competitor_lifted_names_exported``
  fails loudly if any of the six lifted names ever reappear on the
  public module, preventing accidental reintroduction.

Full suite: **955 pass**, 4 skipped, 8 xfailed, 1 xpassed.  Ruff clean.

## Version
Bumps to 0.3.114.
