### PR TITLE
fix: replace eval()-based calculate tool with safe math interpreter (fixes #60)

### DIFF
--- a/examples/python/07-provider-praisonai/app.py
+++ b/examples/python/07-provider-praisonai/app.py
@@ -65,13 +65,11 @@ class FullFeaturedProvider(BaseProvider):
 
         def calculate(expression: str) -> str:
             """Evaluate a math expression safely."""
+            from praisonaiui.math_eval import eval_math_expression
+
             try:
-                # Safe evaluation of basic math
-                allowed = set("0123456789+-*/.() ")
-                if all(c in allowed for c in expression):
-                    result = eval(expression)
-                    return f"Result: {result}"
-                return "Error: Only basic math operations allowed"
+                result = eval_math_expression(expression)
+                return f"Result: {result}"
             except Exception as e:
                 return f"Error: {e}"
 

--- a/src/praisonaiui/cli.py
+++ b/src/praisonaiui/cli.py
@@ -1087,41 +1087,15 @@ def _register_yaml_chat(chat_yaml: dict) -> None:
 
             _resolved_tools.append(web_search)
         elif tname == "calculate":
+            from praisonaiui.math_eval import eval_math_expression
 
             def calculate(expression: str) -> str:
                 """Evaluate a math expression safely."""
-                import ast
-
-                allowed = set("0123456789+-*/.() ")
-                if all(c in allowed for c in expression):
-                    try:
-                        tree = ast.parse(expression, mode="eval")
-                        # Only allow numeric literals and basic operators
-                        for node in ast.walk(tree):
-                            if not isinstance(
-                                node,
-                                (
-                                    ast.Expression,
-                                    ast.BinOp,
-                                    ast.UnaryOp,
-                                    ast.Constant,
-                                    ast.Add,
-                                    ast.Sub,
-                                    ast.Mult,
-                                    ast.Div,
-                                    ast.FloorDiv,
-                                    ast.Mod,
-                                    ast.Pow,
-                                    ast.USub,
-                                    ast.UAdd,
-                                ),
-                            ):
-                                return "Error: Only basic math operations allowed"
-                        result = eval(compile(tree, "<calc>", "eval"))
-                        return f"Result: {result}"
-                    except Exception as e:
-                        return f"Error: {e}"
-                return "Error: Only basic math operations allowed"
+                try:
+                    result = eval_math_expression(expression)
+                    return f"Result: {result}"
+                except Exception as e:
+                    return f"Error: {e}"
 
             _resolved_tools.append(calculate)
 

--- a/src/praisonaiui/math_eval.py
+++ b/src/praisonaiui/math_eval.py
@@ -47,7 +47,12 @@ def eval_math_expression(expression: str) -> float | int:
             op = _BINOPS.get(type(node.op))
             if op is None:
                 raise ValueError("Unsupported operator")
-            return op(_walk(node.left), _walk(node.right))
+            left = _walk(node.left)
+            right = _walk(node.right)
+            if isinstance(node.op, ast.Pow):
+                if abs(right) > 100:
+                    raise ValueError("Exponent too large")
+            return op(left, right)
         if isinstance(node, ast.UnaryOp):
             op = _UNARYOPS.get(type(node.op))
             if op is None:

--- a/src/praisonaiui/math_eval.py
+++ b/src/praisonaiui/math_eval.py
@@ -1,0 +1,62 @@
+"""Safe arithmetic expression evaluation without eval/exec."""
+
+from __future__ import annotations
+
+import ast
+import operator
+
+_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_UNARYOPS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+_ALLOWED_NODES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    *tuple(_BINOPS),
+    *tuple(_UNARYOPS),
+)
+
+
+def eval_math_expression(expression: str) -> float | int:
+    """Evaluate a basic math expression via AST walking (no eval/exec)."""
+    allowed_chars = set("0123456789+-*/.() ")
+    if not expression or not all(c in allowed_chars for c in expression):
+        raise ValueError("Only basic math operations allowed")
+
+    tree = ast.parse(expression.strip(), mode="eval")
+
+    def _walk(node: ast.AST) -> float | int:
+        if isinstance(node, ast.Expression):
+            return _walk(node.body)
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float)):
+                return node.value
+            raise ValueError("Only numeric literals allowed")
+        if isinstance(node, ast.BinOp):
+            op = _BINOPS.get(type(node.op))
+            if op is None:
+                raise ValueError("Unsupported operator")
+            return op(_walk(node.left), _walk(node.right))
+        if isinstance(node, ast.UnaryOp):
+            op = _UNARYOPS.get(type(node.op))
+            if op is None:
+                raise ValueError("Unsupported unary operator")
+            return op(_walk(node.operand))
+        raise ValueError("Unsupported expression")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_NODES):
+            raise ValueError("Only basic math operations allowed")
+
+    return _walk(tree)

--- a/tests/unit/test_math_eval.py
+++ b/tests/unit/test_math_eval.py
@@ -22,3 +22,20 @@ def test_rejects_unsafe_input():
         eval_math_expression("__import__('os').system('id')")
     with pytest.raises(ValueError):
         eval_math_expression("2 + x")
+
+
+def test_exponent_limits():
+    """Test protection against DoS via large exponents."""
+    # Valid small exponents should work
+    assert eval_math_expression("2**3") == 8
+    assert eval_math_expression("3**4") == 81
+    
+    # Large exponents should be rejected
+    with pytest.raises(ValueError, match="Exponent too large"):
+        eval_math_expression("2**101")
+    with pytest.raises(ValueError, match="Exponent too large"):
+        eval_math_expression("2**1000")
+    
+    # Negative large exponents should also be rejected  
+    with pytest.raises(ValueError, match="Exponent too large"):
+        eval_math_expression("2**-101")

--- a/tests/unit/test_math_eval.py
+++ b/tests/unit/test_math_eval.py
@@ -1,0 +1,24 @@
+"""Tests for safe math expression evaluation."""
+
+import pytest
+
+from praisonaiui.math_eval import eval_math_expression
+
+
+def test_basic_arithmetic():
+    assert eval_math_expression("2 + 3") == 5
+    assert eval_math_expression("10 - 4") == 6
+    assert eval_math_expression("3 * 7") == 21
+    assert eval_math_expression("8 / 2") == 4.0
+
+
+def test_parentheses_and_unary():
+    assert eval_math_expression("(2 + 3) * 4") == 20
+    assert eval_math_expression("-5 + 10") == 5
+
+
+def test_rejects_unsafe_input():
+    with pytest.raises(ValueError):
+        eval_math_expression("__import__('os').system('id')")
+    with pytest.raises(ValueError):
+        eval_math_expression("2 + x")


### PR DESCRIPTION
Fixes #60

## Summary

Add `eval_math_expression()` — an AST-walking math evaluator with no `eval()` / `exec()`. Wire into the YAML `calculate` tool (`cli.py`) and the `07-provider-praisonai` example.

## Test evidence

```
tests/unit/test_math_eval.py::test_basic_arithmetic PASSED
tests/unit/test_math_eval.py::test_parentheses_and_unary PASSED
tests/unit/test_math_eval.py::test_rejects_unsafe_input PASSED
```


Made with [Cursor](https://cursor.com)