### PR TITLE
fix: default python app.py examples to 127.0.0.1 (fixes #66)

### DIFF
--- a/examples/python/10-feature-showcase/app.py
+++ b/examples/python/10-feature-showcase/app.py
@@ -13,6 +13,7 @@ Run:
     pip install praisonaiui
     python app.py
     # Dashboard at http://localhost:8082
+    # Set HOST=0.0.0.0 for Docker/LAN demos (defaults to 127.0.0.1)
 """
 
 import sys
@@ -27,8 +28,10 @@ from _shared.seed_data import seed_demo_data
 
 seed_demo_data()
 
+HOST = os.getenv("HOST", "127.0.0.1")
+
 if __name__ == "__main__":
     app = create_app()
     print("✅ Full Dashboard at http://localhost:8082")
     print("   API: http://localhost:8082/api/features")
-    uvicorn.run(app, host="0.0.0.0", port=8082, log_level="info")
+    uvicorn.run(app, host=HOST, port=8082, log_level="info")

--- a/examples/python/10-feature-showcase/app.py
+++ b/examples/python/10-feature-showcase/app.py
@@ -16,11 +16,12 @@ Run:
     # Set HOST=0.0.0.0 for Docker/LAN demos (defaults to 127.0.0.1)
 """
 
-import sys
 import os
+import sys
+
+import uvicorn
 
 from praisonaiui.server import create_app
-import uvicorn
 
 # Use shared seed data helper
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -28,10 +29,9 @@ from _shared.seed_data import seed_demo_data
 
 seed_demo_data()
 
-HOST = os.getenv("HOST", "127.0.0.1")
-
 if __name__ == "__main__":
     app = create_app()
     print("✅ Full Dashboard at http://localhost:8082")
     print("   API: http://localhost:8082/api/features")
-    uvicorn.run(app, host=HOST, port=8082, log_level="info")
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8082, log_level="info")

--- a/examples/python/11-ui-integration/app.py
+++ b/examples/python/11-ui-integration/app.py
@@ -171,7 +171,8 @@ def run_standalone():
 
     aiui_app.routes.insert(0, Route("/", landing, methods=["GET"]))
     print("✅ UI Integration Demo at http://localhost:8082")
-    uvicorn.run(aiui_app, host="0.0.0.0", port=8082, log_level="info")
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(aiui_app, host=host, port=8082, log_level="info")
 
 
 if __name__ == "__main__":

--- a/examples/python/12-agent-dashboard/app.py
+++ b/examples/python/12-agent-dashboard/app.py
@@ -490,4 +490,5 @@ if __name__ == "__main__":
 
     print("✅ Agent Dashboard at http://localhost:8082")
     print("   JSON API: http://localhost:8082/api/features")
-    uvicorn.run(app, host="0.0.0.0", port=8082, log_level="info")
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8082, log_level="info")

--- a/examples/python/15-dashboard-test/app.py
+++ b/examples/python/15-dashboard-test/app.py
@@ -85,5 +85,7 @@ async def metrics_page():
 app = create_app()
 
 if __name__ == "__main__":
+    import os
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8082)
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8082)

--- a/examples/python/16-gateway-integration/app.py
+++ b/examples/python/16-gateway-integration/app.py
@@ -154,13 +154,14 @@ def _register_agents_in_dashboard():
 
 # ── Main ────────────────────────────────────────────────────
 async def main():
+    host = os.getenv("HOST", "127.0.0.1")
     if GATEWAY_OK:
         print("🚀 Starting with Gateway mode (full execution + streaming)")
         print()
 
         # Create the gateway
         gateway = AIUIGateway(
-            host="0.0.0.0",
+            host=host,
             port=8083,
         )
 
@@ -195,7 +196,7 @@ async def main():
         _register_agents_in_dashboard()
 
         app = create_app()
-        config = uvicorn.Config(app, host="0.0.0.0", port=8083, log_level="info")
+        config = uvicorn.Config(app, host=host, port=8083, log_level="info")
         server = uvicorn.Server(config)
         await server.serve()
 

--- a/examples/python/17-three-column-demo/app.py
+++ b/examples/python/17-three-column-demo/app.py
@@ -122,12 +122,13 @@ def _register_agents_in_dashboard():
 
 async def main():
     port = int(os.getenv("PORT", "8082"))
+    host = os.getenv("HOST", "127.0.0.1")
 
     if GATEWAY_OK:
         print("🚀 Starting with Gateway mode (full execution + streaming)")
         print()
 
-        gateway = AIUIGateway(host="0.0.0.0", port=port)
+        gateway = AIUIGateway(host=host, port=port)
 
         # Register agents with gateway for real execution
         for agent_def in AGENTS:
@@ -165,7 +166,7 @@ async def main():
         print(f"   Note:       POST endpoints may fail without gateway")
         print()
 
-        config = uvicorn.Config(app, host="0.0.0.0", port=port, log_level="info")
+        config = uvicorn.Config(app, host=host, port=port, log_level="info")
         server = uvicorn.Server(config)
         await server.serve()
 

--- a/examples/python/18-full-chat/app.py
+++ b/examples/python/18-full-chat/app.py
@@ -122,12 +122,13 @@ def _register_agents_in_dashboard():
 
 async def main():
     port = int(os.getenv("PORT", "8082"))
+    host = os.getenv("HOST", "127.0.0.1")
 
     if GATEWAY_OK:
         print("🚀 Starting with Gateway mode (full execution + streaming)")
         print()
 
-        gateway = AIUIGateway(host="0.0.0.0", port=port)
+        gateway = AIUIGateway(host=host, port=port)
 
         # Register agents with gateway for real execution
         for agent_def in AGENTS:
@@ -165,7 +166,7 @@ async def main():
         print(f"   Note:       POST endpoints may fail without gateway")
         print()
 
-        config = uvicorn.Config(app, host="0.0.0.0", port=port, log_level="info")
+        config = uvicorn.Config(app, host=host, port=port, log_level="info")
         server = uvicorn.Server(config)
         await server.serve()
 

--- a/examples/python/20-email-channel/app.py
+++ b/examples/python/20-email-channel/app.py
@@ -182,4 +182,5 @@ if __name__ == "__main__":
         print(f"✅ Dashboard at http://localhost:8084")
         print(f"   Channels: http://localhost:8084/api/channels")
         print(f"   Platforms: http://localhost:8084/api/channels/platforms")
-        uvicorn.run(app, host="0.0.0.0", port=8084, log_level="info")
+        host = os.getenv("HOST", "127.0.0.1")
+        uvicorn.run(app, host=host, port=8084, log_level="info")

--- a/examples/python/22-agentmail-channel/app.py
+++ b/examples/python/22-agentmail-channel/app.py
@@ -182,4 +182,5 @@ if __name__ == "__main__":
         print(f"✅ Dashboard at http://localhost:8084")
         print(f"   Channels: http://localhost:8084/api/channels")
         print(f"   Platforms: http://localhost:8084/api/channels/platforms")
-        uvicorn.run(app, host="0.0.0.0", port=8084, log_level="info")
+        host = os.getenv("HOST", "127.0.0.1")
+        uvicorn.run(app, host=host, port=8084, log_level="info")

--- a/examples/python/23-e2e-components-test/app.py
+++ b/examples/python/23-e2e-components-test/app.py
@@ -227,5 +227,7 @@ async def on_welcome():
 app = create_app()
 
 if __name__ == "__main__":
+    import os
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8083)
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8083)

--- a/examples/python/28-full-extensibility/app.py
+++ b/examples/python/28-full-extensibility/app.py
@@ -214,7 +214,9 @@ async def custom_view_fallback():
 
 
 if __name__ == "__main__":
+    import os
     import uvicorn
     from praisonaiui.server import create_app
     app = create_app()
-    uvicorn.run(app, host="0.0.0.0", port=8082)
+    host = os.getenv("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=8082)


### PR DESCRIPTION
Fixes #66

## Summary

Bind loopback (`127.0.0.1`) by default in all 11 examples that call `uvicorn` or `AIUIGateway` directly. `HOST` env var overrides for Docker/LAN demos.

## Acceptance criteria

- [x] All 11 files default to `127.0.0.1`
- [x] `HOST` env var overrides bind address
- [x] Example header mentions `HOST=0.0.0.0` for container use
- [x] No change to `aiui run` CLI defaults


Made with [Cursor](https://cursor.com)