### PR TITLE
docs: sync examples/README.md with on-disk examples (fixes #62)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ See also: [`docs/examples/basic.md`](../docs/examples/basic.md) and [`docs/examp
 | 02 | [profiles](yaml/02-profiles/) | YAML agent profiles / persona switching | `aiui run chat.yaml` |
 | 03 | [tools](yaml/03-tools/) | Built-in YAML tool registration | `aiui run chat.yaml` |
 | 04 | [features](yaml/04-features/) | Feature flags and dashboard options in YAML | `aiui run chat.yaml` |
-| 12 | [playground](yaml/12-playground/) | YAML agent playground with multiple profiles | `aiui run chat.yaml` |
+| 12 | [playground](yaml/12-playground/) | YAML agent playground with multiple profiles | `aiui run chat.yaml --style agents` |
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,12 @@
 
 > Each example teaches exactly **one new concept** — no overlap.
 
+See also: [`docs/examples/basic.md`](../docs/examples/basic.md) and [`docs/examples/advanced.md`](../docs/examples/advanced.md).
+
+**Note:** Some folders share numeric prefixes (`02-*`, `19-*`) — treat the path name as the canonical ID, not the number alone.
+
+---
+
 ## Python Track
 
 | # | Name | Unique Concept | Run |
@@ -19,12 +25,28 @@
 | 11 | [ui-integration](python/11-ui-integration/) | Gradio ASGI mount, Streamlit iframe, REST embedding | `python app.py` |
 | 12 | [agent-dashboard](python/12-agent-dashboard/) | OpenClaw-style rendered HTML admin panel | `python app.py` |
 | 13 | [real-dashboard](python/13-real-dashboard/) | Real PraisonAI Agent + native dashboard + live metrics | `aiui run app.py --style dashboard` |
+| 14 | [all-features](python/14-all-features/) | Integration test suite for all 16 feature APIs | `python app.py` |
+| 15 | [dashboard-test](python/15-dashboard-test/) | Protocol-first page registration, view registry | `python app.py` |
+| 16 | [gateway-integration](python/16-gateway-integration/) | `AIUIGateway` — real agent execution + WebSocket streaming | `python app.py` |
+| 17 | [three-column-demo](python/17-three-column-demo/) | Three-column feature explorer with gateway | `python app.py` |
+| 18 | [full-chat](python/18-full-chat/) | `aiui.set_pages()` page curation + custom explorer page | `python app.py` |
 | 19 | [email-bot](python/19-email-bot/) | `EmailBot` IMAP/SMTP + agent replies + subject commands | `python app.py` |
+| 19 | [components-showcase](python/19-components-showcase/) | All 54 UI component types in one dashboard | `aiui run app.py --style dashboard` |
 | 20 | [email-channel](python/20-email-channel/) | Email as AIUI dashboard channel via `/api/channels` | `python app.py` |
 | 21 | [agentmail-bot](python/21-agentmail-bot/) | `AgentMailBot` API-first email + programmatic inbox lifecycle | `python app.py` |
 | 22 | [agentmail-channel](python/22-agentmail-channel/) | AgentMail as AIUI dashboard channel via `/api/channels` | `python app.py` |
+| 23 | [e2e-components-test](python/23-e2e-components-test/) | Components, docs, and chat rendering in one app | `python app.py` |
+| 24 | [custom-design](python/24-custom-design/) | Every chat design knob (`set_theme`, branding, layout) | `aiui run app.py` |
 | 25 | [clean-chat](python/25-clean-chat/) | `set_dashboard(sidebar=False)` — dashboard chat without left nav | `aiui run app.py` |
 | 26 | [custom-theme-chat](python/26-custom-theme-chat/) | `register_theme()` — dynamic custom theme (teal/cyan) | `aiui run app.py` |
+| 27 | [multica-style](python/27-multica-style/) | Multica-inspired UI features (glass, gradients, motion) | `python app.py` |
+| 28 | [full-extensibility](python/28-full-extensibility/) | All extension points: pages, forms, `set_custom_js`, plugins | `python app.py` |
+| 29 | [a2ui-canvas](python/29-a2ui-canvas/) | A2UI canvas + `send_a2ui_messages` integration | `python app.py` |
+| 30 | [image-preview](python/30-image-preview/) | `ImageAgent` inline chat image preview via `MESSAGE_ELEMENT` | `aiui run app.py` |
+| — | [external-agent-dashboard](python/external-agent-dashboard/) | Minimal external agent on dashboard shell | `aiui run app.py` |
+| — | [platform-board](python/platform-board/) | Kanban board from PraisonAI Platform issues API | `aiui run app.py` |
+| — | [praisonai-claw-board](python/praisonai-claw-board/) | Kanban board from `aiui` jobs store | `aiui run app.py` |
+| — | [video-studio](python/video-studio/) | Video Studio — YAML scenes via Video engine sidecar | `aiui run app.py` |
 
 ---
 
@@ -33,22 +55,22 @@
 | # | Name | Shows | Run |
 |---|---|---|---|
 | 01 | [chat](yaml/01-chat/) | Zero-code YAML chat agent | `aiui run chat.yaml` |
-| 02 | [clean-chat](yaml/02-clean-chat/) | `dashboard.sidebar: false` — dashboard chat without left nav (YAML parity) | `aiui run clean-chat.yaml` |
+| 02 | [clean-chat](yaml/02-clean-chat/) | `dashboard.sidebar: false` — dashboard chat without left nav | `aiui run clean-chat.yaml` |
+| 02 | [profiles](yaml/02-profiles/) | YAML agent profiles / persona switching | `aiui run chat.yaml` |
+| 03 | [tools](yaml/03-tools/) | Built-in YAML tool registration | `aiui run chat.yaml` |
+| 04 | [features](yaml/04-features/) | Feature flags and dashboard options in YAML | `aiui run chat.yaml` |
+| 12 | [playground](yaml/12-playground/) | YAML agent playground with multiple profiles | `aiui run chat.yaml` |
 
 ---
 
 ## YAML Track — Site Templates
 
-| # | Name | Shows |
-|---|---|---|
-| 01 | minimal | 5-line YAML → live docs site |
-| 02 | with-sidebar | `DocsSidebar` slot, directory-based navigation |
-| 03 | with-toc | `Toc` slot, right-column table of contents |
-| 04 | multi-section | Multiple content directories and grouped routes |
-| 05 | custom-homepage | `Hero` + `FeatureList` slot components |
-| 06 | fullstack | Header/Footer refs, CTA buttons, dark mode |
-| 07 | seo-config | `<meta>` tags, `<title>` per-page, Open Graph |
-| 08 | api-reference | `ApiSidebar`, route-level slot overrides |
-| 09 | typescript-custom | Custom TypeScript component registration |
-| 10 | i18n-ready | Multi-language content directories |
-| 11 | monorepo | Workspaces, shared components, per-package docs |
+| # | Name | Shows | Run |
+|---|---|---|---|
+| 05 | [minimal](yaml/05-minimal/) | 5-line YAML → live docs site | `aiui build --config aiui.template.yaml` |
+| 06 | [blocks](yaml/06-blocks/) | shadcn component dependency installation | `aiui build --config aiui.template.yaml` |
+| 07 | [colorful](yaml/07-colorful/) | Colourful marketing theme with hero zones | `aiui build --config aiui.template.yaml` |
+| 08 | [corporate](yaml/08-corporate/) | Corporate docs with SEO, i18n, and a11y fields | `aiui build --config aiui.template.yaml` |
+| 09 | [dark-modern](yaml/09-dark-modern/) | Dark-mode modern docs layout | `aiui build --config aiui.template.yaml` |
+| 10 | [developer-portal](yaml/10-developer-portal/) | API reference sidebar and route overrides | `aiui build --config aiui.template.yaml` |
+| 11 | [full-featured](yaml/11-full-featured/) | Full enterprise config (SEO, i18n, a11y, search) | `aiui build --config aiui.template.yaml` |


### PR DESCRIPTION
Fixes #62

## Summary

Rewrite `examples/README.md` to index all 35 Python apps, 13 YAML examples, and real site template folder names (`05-minimal` … `11-full-featured`). Remove fictional template names and note duplicate numeric prefixes.

## Acceptance criteria

- [x] Every directory under `examples/python/*/app.py` and `examples/yaml/` appears in README
- [x] No fictional template folder names remain
- [x] Run commands match each example's docstring
- [x] Duplicate `02-*` / `19-*` numbering called out


Made with [Cursor](https://cursor.com)