### PR TITLE
fix(ci): dedupe Claude workflow double triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,6 +8,9 @@ name: Claude Assistant
 #   - pull_request_review → full implementation when @claude mentioned in review
 #   - pull_request_review_comment → full implementation when @claude mentioned inline
 #
+# Escalate an issue with the `claude` label OR an @claude comment — not both.
+# If both fire within 3 minutes, the comment trigger is skipped (dedupe job).
+#
 # Focus: CLAUDE only. Copilot and CodeRabbit are GitHub Apps that react to PRs
 # automatically — no workflow file needed. auto-pr-comment.yml orchestrates the
 # CodeRabbit → Copilot → Claude review chain for PRs.
@@ -136,10 +139,11 @@ jobs:
   # ================================================================
   # Job 2 — Full Claude Code implementation
   # Triggers on: labeled `claude`, @claude comments, assignments
+  #
+  # Dedup: label + @claude comment on the same issue fires two events.
+  # Skip the comment trigger when `claude` was labelled within 3 minutes.
   # ================================================================
-  claude-response:
-    env:
-      ISSUE_NUMBER_RESOLVED: ${{ github.event.issue.number || github.event.pull_request.number }}
+  claude-dedupe:
     if: |
       github.event.action != 'opened' &&
       (github.event.action != 'labeled' || github.event.label.name == 'claude') &&
@@ -152,6 +156,55 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       github.actor != 'cursor[bot]' &&
       github.actor != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Skip duplicate comment after fresh claude label
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== 'issue_comment' || context.payload.issue?.pull_request) {
+              core.setOutput('proceed', 'true');
+              return;
+            }
+            const issue = context.payload.issue;
+            const hasClaude = (issue.labels || []).some(l => l.name === 'claude');
+            if (!hasClaude) {
+              core.setOutput('proceed', 'true');
+              return;
+            }
+            const events = await github.rest.issues.listEvents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 30,
+            });
+            const windowMs = 3 * 60 * 1000;
+            const recentLabel = events.data.find(e =>
+              e.event === 'labeled' &&
+              e.label?.name === 'claude' &&
+              (Date.now() - new Date(e.created_at).getTime()) < windowMs
+            );
+            if (recentLabel) {
+              core.info('Skipping: claude label was added within 3 minutes — label trigger already handles this issue.');
+              core.setOutput('proceed', 'false');
+              return;
+            }
+            core.setOutput('proceed', 'true');
+
+  claude-response:
+    needs: claude-dedupe
+    env:
+      ISSUE_NUMBER_RESOLVED: ${{ github.event.issue.number || github.event.pull_request.number }}
+    if: needs.claude-dedupe.outputs.proceed == 'true'
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

Each issue was running Claude **twice** because two events fired per issue:
1. `issues:labeled` → `claude` label added
2. `issue_comment` → `@claude` comment posted

## Fix

- **Dedupe job**: skip `issue_comment` trigger when `claude` label was added within 3 minutes (label trigger already handles it)
- **Concurrency**: one run per issue; cancel overlapping runs
- **Docs**: escalate with label **or** `@claude` comment, not both

## Test plan

- [ ] Add `claude` label only → single run
- [ ] `@claude` comment only → single run
- [ ] Label + comment within 3 min → single run (comment skipped)
- [ ] `@claude` comment after 3 min on labelled issue → runs (follow-up)


Made with [Cursor](https://cursor.com)