### PR TITLE
fix(ci): PR auto-Claude final review (parity with PraisonAI)

### DIFF
--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -16,11 +16,19 @@ on:
     types: [submitted]
   pull_request:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to trigger Claude final review on'
+        required: true
+        type: number
 
 env:
   MAX_POLL_ATTEMPTS: 20
   POLL_DELAY_MS: 30000
   CLAUDE_TRIGGER_LOGINS: '["MervinPraison","github-actions[bot]"]'
+  # GH_TOKEN (user PAT) posts as MervinPraison for @copilot; fallback to github.token for @claude
+  GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
 
 jobs:
   # ================================================================
@@ -43,7 +51,7 @@ jobs:
         id: trigger
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
@@ -86,7 +94,7 @@ jobs:
         id: trigger
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
@@ -134,12 +142,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
+            const pr = parseInt(process.env.PR_NUMBER, 10);
             const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
             const comments = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
+              issue_number: pr,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
@@ -148,23 +158,25 @@ jobs:
             );
             core.setOutput('already_triggered', alreadyPosted ? 'true' : 'false');
             core.setOutput('comments_count', comments.data.length.toString());
-          
-            // Collect all bot reviewer comments for context
-            const botReviews = comments.data.filter(c => 
-              ['coderabbitai[bot]', 'qodo-code-review[bot]', 'gemini-code-assist[bot]', 
-               'copilot-swe-agent', 'Copilot', 'greptile-apps[bot]'].some(bot => 
+
+            const botReviews = comments.data.filter(c =>
+              ['coderabbitai[bot]', 'qodo-code-review[bot]', 'gemini-code-assist[bot]',
+               'copilot-swe-agent', 'Copilot', 'greptile-apps[bot]'].some(bot =>
                 c.user.login.toLowerCase().includes(bot.toLowerCase())
               )
             );
             core.setOutput('review_count', botReviews.length.toString());
-          
+
       - name: Aggregate reviews and trigger Claude
         if: steps.check_claude.outputs.already_triggered != 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
-            const comments = await github.rest.issues.listComments({issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo, per_page: 100});
+            const pr = parseInt(process.env.PR_NUMBER, 10);
+            const comments = await github.rest.issues.listComments({issue_number: pr, owner: context.repo.owner, repo: context.repo.repo, per_page: 100});
             const reviews = {coderabbit: [], qodo: [], gemini: [], copilot: [], greptile: [], others: []};
             comments.data.forEach(c => {
               const login = c.user.login.toLowerCase();
@@ -183,14 +195,14 @@ jobs:
             if (reviews.copilot.length) summaryParts.push('Copilot: ' + reviews.copilot.length + ' comments');
             if (reviews.greptile.length) summaryParts.push('Greptile: ' + reviews.greptile.length + ' comments');
             const reviewSummary = summaryParts.length ? summaryParts.join(' | ') : 'No bot reviews detected';
-            const claudeBody = '@claude You are the FINAL architecture reviewer. If the branch is under MervinPraison/PraisonAIUI (not a fork), you are able to make modifications to this branch and push directly. SCOPE: Focus ONLY on PraisonAIUI (src/praisonaiui, tests, docs). Do not expand scope into praisonaiagents or the monorepo unless the issue explicitly requires it. ' + reviewSummary + '.\n\n' +
-              'Review Context: ' + comments.data.length + ' total comments, ' + 
+            const claudeBody = '@claude You are the FINAL architecture reviewer. If the branch is under MervinPraison/PraisonAIUI (not a fork), you are able to make modifications to this branch and push directly. SCOPE: Focus ONLY on PraisonAIUI (src/praisonaiui, src/frontend, tests, docs). Read ALL prior reviewer comments. ' + reviewSummary + '.\n\n' +
+              'Review Context: ' + comments.data.length + ' total comments, ' +
               (reviews.coderabbit.length + reviews.qodo.length + reviews.gemini.length + reviews.copilot.length + reviews.greptile.length) + ' bot reviews.\n\n' +
-              'Phase 1: Review per AGENTS.md principles (protocol-driven, backward compatible, no perf impact).\n' +
-              'Phase 2: FIX valid issues found by prior reviewers.\n' +
-              'Phase 3: Provide final verdict (approve or request changes).';
-            await github.rest.issues.createComment({issue_number: context.issue.number, owner: context.repo.owner, repo: context.repo.repo, body: claudeBody});
-            console.log('Claude fallback triggered on PR #' + context.issue.number + ' with ' + reviewSummary);
+              '**Phase 1: Review per AGENTS.md** (lazy imports, backward compat, import-time <200ms)\n' +
+              '**Phase 2: FIX valid issues** found by prior reviewers — push to THIS branch\n' +
+              '**Phase 3: Final verdict** — approve PR if ready, else request changes';
+            await github.rest.issues.createComment({issue_number: pr, owner: context.repo.owner, repo: context.repo.repo, body: claudeBody});
+            console.log('Claude fallback triggered on PR #' + pr + ' with ' + reviewSummary);
 
   # ================================================================
   # Claude FINAL review — polls for Copilot's response, then triggers
@@ -217,7 +229,7 @@ jobs:
           MAX_POLL_ATTEMPTS: ${{ env.MAX_POLL_ATTEMPTS }}
           POLL_DELAY_MS: ${{ env.POLL_DELAY_MS }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             const owner = context.repo.owner;
@@ -286,7 +298,7 @@ jobs:
           PR_NUMBER: ${{ needs.copilot-after-coderabbit.outputs.pr_number }}
           TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
@@ -306,7 +318,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.copilot-after-coderabbit.outputs.pr_number }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             await github.rest.issues.createComment({
@@ -340,7 +352,7 @@ jobs:
           MAX_POLL_ATTEMPTS: ${{ env.MAX_POLL_ATTEMPTS }}
           POLL_DELAY_MS: ${{ env.POLL_DELAY_MS }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             const owner = context.repo.owner;
@@ -390,7 +402,7 @@ jobs:
           PR_NUMBER: ${{ needs.copilot-after-qodo.outputs.pr_number }}
           TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
@@ -410,7 +422,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.copilot-after-qodo.outputs.pr_number }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             await github.rest.issues.createComment({
@@ -445,7 +457,7 @@ jobs:
         env:
           TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
             const comments = await github.rest.issues.listComments({
@@ -462,7 +474,7 @@ jobs:
         if: steps.check_claude.outputs.already_triggered != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -492,7 +504,7 @@ jobs:
       - name: Trigger CodeRabbit and Qodo reviews
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
           script: |
             const pr = context.payload.pull_request.number;
             const owner = context.repo.owner;
@@ -523,3 +535,101 @@ jobs:
             // It will be triggered by copilot-after-coderabbit or copilot-after-qodo
             // once those bots finish, ensuring Copilot always reviews LAST.
             console.log('Copilot will be triggered after CodeRabbit/Qodo complete.');
+
+  # ================================================================
+  # BOT PRs: CodeRabbit → Claude directly (skip Copilot when no user PAT)
+  # Copilot ignores github-actions[bot] comments; bot PRs use this path.
+  # ================================================================
+  claude-after-coderabbit-bot-pr:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'coderabbitai[bot]' &&
+      contains(github.event.comment.body, 'summarize by coderabbit')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Trigger Claude final review on bot PR
+        uses: actions/github-script@v7
+        env:
+          TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            const pr = context.issue.number;
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr,
+            });
+            const author = pull.user.login;
+            const isBot = author === 'github-actions[bot]' ||
+              author === 'praisonai-triage-agent[bot]' ||
+              pull.user.type === 'Bot';
+            if (!isBot) {
+              console.log('Human PR — Copilot chain handles Claude trigger');
+              return;
+            }
+            const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
+            const comments = await github.rest.issues.listComments({
+              issue_number: pr,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const alreadyPosted = comments.data.some(c =>
+              c.body.includes('@claude') && triggerLogins.includes(c.user.login)
+            );
+            if (alreadyPosted) {
+              console.log('Claude already triggered on PR #' + pr);
+              return;
+            }
+            await github.rest.issues.createComment({
+              issue_number: pr,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@claude You are the FINAL architecture reviewer on this bot-authored PR. Push fixes directly to THIS branch (do NOT open a new PR). SCOPE: PraisonAIUI only (src/praisonaiui, src/frontend, tests, docs). Read ALL CodeRabbit/Qodo comments above.\n\n**Phase 1:** Review per AGENTS.md (lazy imports, backward compat, import-time <200ms)\n**Phase 2:** FIX valid reviewer issues on this branch\n**Phase 3:** Approve PR if ready, else request changes with clear action items'
+            });
+            console.log('Claude final review triggered on bot PR #' + pr);
+
+  # ================================================================
+  # Manual: trigger Claude final review on any PR
+  # ================================================================
+  claude-manual-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Trigger Claude final review
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          TRIGGER_LOGINS: ${{ env.CLAUDE_TRIGGER_LOGINS }}
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            const pr = parseInt(process.env.PR_NUMBER, 10);
+            const triggerLogins = JSON.parse(process.env.TRIGGER_LOGINS);
+            const comments = await github.rest.issues.listComments({
+              issue_number: pr,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const alreadyPosted = comments.data.some(c =>
+              c.body.includes('@claude') && triggerLogins.includes(c.user.login)
+            );
+            if (alreadyPosted) {
+              console.log('Claude already triggered on PR #' + pr);
+              return;
+            }
+            await github.rest.issues.createComment({
+              issue_number: pr,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@claude You are the FINAL architecture reviewer. Push fixes directly to THIS branch. SCOPE: PraisonAIUI (src/praisonaiui, src/frontend, tests, docs). Read all prior reviewer comments.\n\n**Phase 1:** Review per AGENTS.md\n**Phase 2:** FIX valid issues on this branch\n**Phase 3:** Approve PR if ready, else request changes'
+            });
+            console.log('Claude manually triggered on PR #' + pr);


### PR DESCRIPTION
## Summary

Enable the same PR review chain as `~/praisonai-package`:

```
CodeRabbit/Qodo → Copilot (if GH_TOKEN) → Claude final approve/fix
Bot PRs:         CodeRabbit → Claude directly (Copilot ignores bot comments)
Fallback:        15 min after PR open → Claude if chain skipped
```

## Fixes

- `GH_TOKEN` falls back to `github.token` (was broken — secret missing)
- `claude-fallback-timeout` used `context.issue` on `pull_request` events (never fired)
- Bot PRs (`github-actions[bot]`) get direct CodeRabbit → Claude path
- `workflow_dispatch` with `pr_number` for manual trigger

## Test plan

- [ ] Open bot PR → CodeRabbit → @claude final review
- [ ] `workflow_dispatch` on existing PR → Claude runs
- [ ] 15 min fallback triggers if chain skips


Made with [Cursor](https://cursor.com)