### PR TITLE
fix(ci): workflow permissions for PR Claude triggers

### DIFF
--- a/.github/workflows/auto-pr-comment.yml
+++ b/.github/workflows/auto-pr-comment.yml
@@ -23,6 +23,11 @@ on:
         required: true
         type: number
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 env:
   MAX_POLL_ATTEMPTS: 20
   POLL_DELAY_MS: 30000


### PR DESCRIPTION
Adds issues:write + pull-requests:write at workflow level for auto-pr-comment.yml.

Made with [Cursor](https://cursor.com)