### PR TITLE
fix: explicit UTF-8 encoding for text file reads on Windows (fixes #133)

### DIFF
--- a/src/praisonaiui/cli.py
+++ b/src/praisonaiui/cli.py
@@ -213,7 +213,7 @@ def validate(
         raise typer.Exit(code=2)
 
     try:
-        with open(config) as f:
+        with open(config, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         cfg = Config.model_validate(data)
     except Exception as e:
@@ -264,7 +264,7 @@ def build(
         raise typer.Exit(code=2)
 
     try:
-        with open(config) as f:
+        with open(config, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         cfg = Config.model_validate(data)
     except Exception as e:
@@ -549,7 +549,7 @@ def dev(
                 )
                 tmp_cfg = None
                 if has_override and config_file.exists():
-                    with open(config_file) as f:
+                    with open(config_file, encoding="utf-8") as f:
                         config = yaml.safe_load(f.read())
                     if "site" not in config:
                         config["site"] = {}
@@ -945,7 +945,7 @@ def dev(
                         yaml_path = examples_dir / example_name / "aiui.template.yaml"
                         yaml_content = ""
                         if yaml_path.exists():
-                            with open(yaml_path) as f:
+                            with open(yaml_path, encoding="utf-8") as f:
                                 yaml_content = f.read()
                         self.send_response(200)
                         self.send_header("Content-type", "application/json")
@@ -1351,7 +1351,7 @@ def run(
         console.print(f"[yellow]⏳[/yellow] Loading {app_file}...")
         import yaml as _yaml
 
-        with open(app_file) as f:
+        with open(app_file, encoding="utf-8") as f:
             chat_yaml = _yaml.safe_load(f) or {}
 
         # Apply config from YAML (override CLI defaults only if present)

--- a/src/praisonaiui/compiler/compiler.py
+++ b/src/praisonaiui/compiler/compiler.py
@@ -471,7 +471,7 @@ class Compiler:
         """Patch anti-flicker script in index.html to respect darkMode."""
         theme = self.config.site.theme
         dark_mode = theme.dark_mode if theme else True
-        html = html_path.read_text()
+        html = html_path.read_text(encoding="utf-8")
         if not dark_mode:
             # Remove the dark class addition for light-mode sites
             html = html.replace(
@@ -538,7 +538,7 @@ class Compiler:
         if not template_path.exists():
             return []
 
-        template_html = template_path.read_text()
+        template_html = template_path.read_text(encoding="utf-8")
         site_title = self.config.site.title
         site_desc = self.config.site.description or f"Documentation built with {site_title}"
         files: list[str] = []
@@ -677,7 +677,7 @@ class Compiler:
         md_content = None
         for candidate in md_candidates:
             if candidate.exists():
-                md_content = candidate.read_text()
+                md_content = candidate.read_text(encoding="utf-8")
                 break
 
         if not md_content:

--- a/src/praisonaiui/components.py
+++ b/src/praisonaiui/components.py
@@ -222,7 +222,7 @@ def update_component_exports(frontend_path: Optional[Path] = None) -> bool:
         return False
 
     # Read current exports
-    current_content = index_path.read_text()
+    current_content = index_path.read_text(encoding="utf-8")
 
     # Check which components are missing from exports
     missing_exports = []

--- a/src/praisonaiui/config_store.py
+++ b/src/praisonaiui/config_store.py
@@ -145,7 +145,7 @@ class YAMLConfigStore:
         try:
             import yaml
 
-            with open(self._path) as f:
+            with open(self._path, encoding="utf-8") as f:
                 loaded = yaml.safe_load(f) or {}
             # Merge with defaults so new keys are always present
             self._data = copy.deepcopy(_DEFAULT_CONFIG)
@@ -200,7 +200,7 @@ class YAMLConfigStore:
             return
 
         try:
-            with open(json_path) as f:
+            with open(json_path, encoding="utf-8") as f:
                 data = json.load(f)
             agents = data.get("agents", {})
             if agents:

--- a/src/praisonaiui/features/memory.py
+++ b/src/praisonaiui/features/memory.py
@@ -413,7 +413,7 @@ class SDKMemoryManager(MemoryProtocol):
                 if json_file.name == "config.json":
                     continue
                 try:
-                    data = json.loads(json_file.read_text())
+                    data = json.loads(json_file.read_text(encoding="utf-8"))
                     if not isinstance(data, list):
                         continue
                     # Determine type from filename

--- a/src/praisonaiui/features/usage.py
+++ b/src/praisonaiui/features/usage.py
@@ -290,7 +290,7 @@ def _load_data() -> None:
     if not _data_file or not _data_file.exists():
         return
     try:
-        with open(_data_file) as f:
+        with open(_data_file, encoding="utf-8") as f:
             data = json.load(f)
         _aggregates.update(data.get("aggregates", {}))
         for record in data.get("records", []):

--- a/src/praisonaiui/integration.py
+++ b/src/praisonaiui/integration.py
@@ -299,7 +299,7 @@ def create_gateway_from_yaml(
     if not os.path.exists(config_path):
         raise FileNotFoundError(f"Config not found: {config_path}")
 
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     # Extract gateway settings

--- a/src/praisonaiui/server.py
+++ b/src/praisonaiui/server.py
@@ -2502,7 +2502,7 @@ def load_config_from_yaml(config_path: Path) -> Optional[dict]:
     try:
         import yaml
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             return yaml.safe_load(f)
     except Exception:
         return None

--- a/src/praisonaiui/test_runner.py
+++ b/src/praisonaiui/test_runner.py
@@ -311,7 +311,7 @@ def test_sessions(server: str = _SERVER_OPT) -> None:
     r.check(f"Session file exists: {session_file.name}", session_file.exists())
 
     if session_file.exists():
-        data = json.loads(session_file.read_text())
+        data = json.loads(session_file.read_text(encoding="utf-8"))
         file_msgs = data.get("messages", [])
         r.check(
             "File contains messages",
@@ -798,7 +798,7 @@ def test_features(server: str = _SERVER_OPT) -> None:
         # Try loading from .env
         for env_path in [Path.cwd() / ".env", Path.home() / ".env"]:
             if env_path.exists():
-                for line in env_path.read_text().splitlines():
+                for line in env_path.read_text(encoding="utf-8").splitlines():
                     if line.startswith("TELEGRAM_BOT_TOKEN="):
                         tg_token = line.split("=", 1)[1].strip().strip('"').strip("'")
                         break

--- a/src/praisonaiui/themes.py
+++ b/src/praisonaiui/themes.py
@@ -246,7 +246,7 @@ def _read_disk_cache() -> Optional[dict]:
         age = time.time() - path.stat().st_mtime
         if age > _DISK_CACHE_TTL:
             return None
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
 


### PR DESCRIPTION
Fixes #133

## Summary

Fixes `aiui build` / `aiui serve` failing on Windows with `UnicodeDecodeError` when reading UTF-8 files using the system default encoding (cp1252).

## Changes

Adds explicit `encoding=\"utf-8\"` to text file reads across:
- `cli.py`, `compiler/compiler.py`, `components.py`, `config_store.py`
- `features/memory.py`, `features/usage.py`, `integration.py`
- `server.py`, `test_runner.py`, `themes.py`

## Test evidence

Branch was produced by Claude Assistant; verify with Windows or encoding-focused pytest on affected modules.