### PR TITLE
fix: doctor Gateway check uses /api/provider endpoint (fixes #134)

### DIFF
--- a/src/praisonaiui/cli.py
+++ b/src/praisonaiui/cli.py
@@ -3035,15 +3035,10 @@ def doctor(
 
     # Check 3: Gateway Status
     def _gateway_extractor(data):
-        # Extract health status from nested health object
-        health = data.get("health", {}) if isinstance(data.get("health"), dict) else {}
-        status = health.get("status", "unknown")
-        # Get provider type from health data or fall back to provider name
-        provider_type = health.get("provider", data.get("name", "unknown"))
-        # Count agents from the agents array
+        status = data.get("status", "unknown")
+        provider_type = data.get("provider", data.get("name", "unknown"))
         agents_list = data.get("agents", [])
         agent_count = len(agents_list) if isinstance(agents_list, list) else 0
-        # Pass if status is ok or healthy
         check_status = "pass" if status in ("ok", "healthy") else "warn"
         return check_status, f"{provider_type} ({agent_count} agents)"
 

--- a/src/praisonaiui/cli.py
+++ b/src/praisonaiui/cli.py
@@ -3035,11 +3035,19 @@ def doctor(
 
     # Check 3: Gateway Status
     def _gateway_extractor(data):
-        gw_type = data.get("type", "unknown")
-        agents = data.get("agents", 0)
-        return "pass", f"{gw_type} ({agents} agents)"
+        # Extract health status from nested health object
+        health = data.get("health", {}) if isinstance(data.get("health"), dict) else {}
+        status = health.get("status", "unknown")
+        # Get provider type from health data or fall back to provider name
+        provider_type = health.get("provider", data.get("name", "unknown"))
+        # Count agents from the agents array
+        agents_list = data.get("agents", [])
+        agent_count = len(agents_list) if isinstance(agents_list, list) else 0
+        # Pass if status is ok or healthy
+        check_status = "pass" if status in ("ok", "healthy") else "warn"
+        return check_status, f"{provider_type} ({agent_count} agents)"
 
-    checks.append(_check("Gateway Status", "/api/provider/health", _gateway_extractor))
+    checks.append(_check("Gateway Status", "/api/provider", _gateway_extractor))
 
     # Check 4: Features Loaded
     def _features_extractor(data):


### PR DESCRIPTION
Fixes #134

## Summary

Fixes `aiui doctor` Gateway check failing because it called missing `/api/provider/health`. Updates the check to use the existing `/api/provider` endpoint.

## Changes

- `src/praisonaiui/cli.py` — align doctor Gateway health probe with available provider API route

## Test evidence

Branch was produced by Claude Assistant; run `aiui doctor` against a local server to confirm Gateway check passes.